### PR TITLE
ElGamal group generation

### DIFF
--- a/internal/dlog/dlog_test.go
+++ b/internal/dlog/dlog_test.go
@@ -39,7 +39,7 @@ func getParams() (*params, error) {
 
 	return &params{
 		p:     key.P,
-		order: new(big.Int).Sub(key.P, big.NewInt(1)),
+		order: key.Q,
 		g:     key.G,
 	}, nil
 }


### PR DESCRIPTION
We correct the elgamal group generation to give g a generator of the subgroup of quadratic residues of Z_p, where p is a strong prime. This change is done since it is known that DDH assumption does not hold in general Z_p* group while it is believed it holds in the subgroup of quadratic residues.