### PR TITLE
An ABE scheme

### DIFF
--- a/abe/abe.go
+++ b/abe/abe.go
@@ -13,14 +13,14 @@ import (
 )
 
 // ABEParams represents configuration parameters for the ABE scheme instance.
-type ABEParams struct {
+type abeParams struct {
 	L int      // number of attributes
 	P *big.Int // order of the elliptic curve
 }
 
 // ABE represents an ABE scheme.
 type ABE struct {
-	Params *ABEParams
+	Params *abeParams
 }
 
 // NewABE configures a new instance of the scheme.
@@ -28,7 +28,7 @@ type ABE struct {
 // the scheme. Attributes' names will be considered as
 // elements of a set {0, 1,..., l-1}.
 func NewABE(l int) *ABE {
-	return &ABE{Params: &ABEParams{
+	return &ABE{Params: &abeParams{
 		L: l, // number of attributes in the whole universe
 		P: bn256.Order,
 	}}

--- a/abe/abe.go
+++ b/abe/abe.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"math/big"
 
+	"strconv"
+	"strings"
+
 	"github.com/cloudflare/bn256"
 	"github.com/fentec-project/gofe/data"
 	"github.com/fentec-project/gofe/sample"
@@ -76,7 +79,7 @@ type Msp struct {
 	rowToAttrib []int
 }
 
-func (a Abe) KeyGen(msp Msp, sk data.Vector) (data.VectorG1, error) {
+func (a Abe) KeyGen(msp *Msp, sk data.Vector) (data.VectorG1, error) {
 	if len(msp.mat) == 0 || len(msp.mat[0]) == 0 {
 		return nil, fmt.Errorf("empty msp matrix")
 	}
@@ -124,7 +127,7 @@ type AbeKey struct {
 	rowToAttrib []int
 }
 
-func (a Abe) DelagateKeys(keys data.VectorG1, msp Msp, attrib []int) *AbeKey {
+func (a Abe) DelagateKeys(keys data.VectorG1, msp *Msp, attrib []int) *AbeKey {
 	attribMap := make(map[int]bool)
 	for _, e := range attrib {
 		attribMap[e] = true
@@ -153,6 +156,9 @@ func (a Abe) Decrypt(cipher *AbeCipher, key *AbeKey) (*bn256.GT, error) {
 	}
 
 	alpha, err := gaussianElimination(key.mat.Transpose(), ones, a.Params.p)
+	ww, _ := key.mat.Transpose().MulVec(alpha)
+	ww = ww.Mod(a.Params.p)
+	fmt.Println("here2", ww)
 	if err != nil {
 		return nil, err
 	}
@@ -167,11 +173,169 @@ func (a Abe) Decrypt(cipher *AbeCipher, key *AbeKey) (*bn256.GT, error) {
 	return ret, nil
 }
 
+// BooleanToMsp takes as an input a boolean expression (without a NOT gate) and
+// outputs a msp structure representing the expression, i.e. a matrix whose rows
+// correspond to attributes used in the expression and with the property that a
+// boolean expression assigning 1 to some attributes is satisfied iff the
+// corresponding rows span a vector [1, 1,..., 1] in Z_p, and a vector whose i-th entry
+// indicates to which attribute the i-th row corresponds.
+func BooleanToMsp(boolExp string, p *big.Int) (*Msp, error) {
+	vec := make(data.Vector, 1)
+	vec[0] = big.NewInt(1)
+	msp, _, err := booleanToMspIterative(boolExp, vec, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	// create an invertible matrix that maps [1, 0,..., 0] to [1,1,...,1]
+	perm := make(data.Matrix, len(msp.mat[0]))
+	fmt.Println(msp.mat)
+	for i:=0; i < len(msp.mat[0]); i++ {
+		perm[i] = make(data.Vector, len(msp.mat[0]))
+		for j:=0; j < len(msp.mat[0]); j++ {
+			if i == 0 || j == i {
+				perm[i][j] = big.NewInt(1)
+			} else {
+				perm[i][j] = big.NewInt(0)
+			}
+
+		}
+	}
+	fmt.Println(perm)
+	msp.mat, err = msp.mat.Mul(perm)
+	msp.mat = msp.mat.Mod(p)
+	return msp, err
+}
+
+// booleanToMspIterative iteratively builds a msp structure by splitting the expression
+// into two parts separated by an AND or OR gate, generating a msp structure on each of
+// them, and joining both structures together. The structure is such the boolean expression
+// assigning 1 to some attributes is satisfied iff the corresponding rows span a vector
+// [1, 0,..., 0]. The algorithm is known as Lewko-Waters algorithm, see Appendix G in
+// https://eprint.iacr.org/2010/351.pdf.
+func booleanToMspIterative(boolExp string, vec data.Vector, c int) (*Msp, int, error) {
+	boolExp = strings.TrimSpace(boolExp)
+	numBrc := 0
+	var boolExp1 string
+	var boolExp2 string
+	var c1 int
+	var cOut int
+	var msp1 *Msp
+	var msp2 *Msp
+	var err error
+	found := false
+
+	// find the main AND or OR gate
+	for i, e := range boolExp {
+		if e == '(' {
+			numBrc++
+			continue
+		}
+		if e == ')' {
+			numBrc--
+			continue
+		}
+		if numBrc == 0 && i < len(boolExp)-3 && boolExp[i:i+3] == "AND" {
+			boolExp1 = boolExp[:i]
+			boolExp2 = boolExp[i+3:]
+			vec1, vec2 := makeAndVecs(vec, c)
+			msp1, c1, err = booleanToMspIterative(boolExp1, vec1, c+1)
+			if err != nil {
+				return nil, 0, err
+			}
+			msp2, cOut, err = booleanToMspIterative(boolExp2, vec2, c1)
+			if err != nil {
+				return nil, 0, err
+			}
+			found = true
+			break
+		}
+		if numBrc == 0 && i < len(boolExp)-2 && boolExp[i:i+2] == "OR" {
+			boolExp1 = boolExp[:i]
+			boolExp2 = boolExp[i+2:]
+			msp1, c1, err = booleanToMspIterative(boolExp1, vec, c)
+			if err != nil {
+				return nil, 0, err
+			}
+			msp2, cOut, err = booleanToMspIterative(boolExp2, vec, c1)
+			if err != nil {
+				return nil, 0, err
+			}
+			found = true
+			break
+		}
+	}
+
+	// If the AND or OR gate is not found then there are two options,
+	// ether the whole expression is in brackets, or the the expression
+	// is only one attribute. It nether of both is is true, then
+	// an error is returned while converting the expression into an
+	// attribute
+	if found == false {
+		if boolExp[0] == '(' && boolExp[len(boolExp)-1] == ')' {
+			boolExp = boolExp[1:(len(boolExp) - 1)]
+			return booleanToMspIterative(boolExp, vec, c)
+		}
+
+		attrib, err := strconv.Atoi(boolExp)
+		if err != nil {
+			return nil, 0, err
+		}
+		mat := make(data.Matrix, 1)
+		mat[0] = make(data.Vector, c)
+		for i := 0; i < c; i++ {
+			mat[0][i] = new(big.Int).Set(vec[i])
+		}
+		rowToAttrib := make([]int, 1)
+		rowToAttrib[0] = attrib
+		return &Msp{mat: mat, rowToAttrib: rowToAttrib}, c, nil
+	} else {
+		// otherwise we join the two msp structures into one
+		mat := make(data.Matrix, len(msp1.mat)+len(msp2.mat))
+		for i := 0; i < len(msp1.mat); i++ {
+			mat[i] = make(data.Vector, cOut)
+			for j := 0; j < len(msp1.mat[0]); j++ {
+				mat[i][j] = msp1.mat[i][j]
+			}
+			for j := len(msp1.mat[0]); j < cOut; j++ {
+				mat[i][j] = big.NewInt(0)
+			}
+		}
+		for i := 0; i < len(msp2.mat); i++ {
+			mat[i+len(msp1.mat)] = msp2.mat[i]
+		}
+		rowToAttrib := append(msp1.rowToAttrib, msp2.rowToAttrib...)
+
+		return &Msp{mat: mat, rowToAttrib: rowToAttrib}, cOut, nil
+	}
+}
+
+// makeAndVecs is a helping structure that given a vector and and counter
+// creates two new vectors used whenever an AND gate is found in a iterative
+// step of BooleanToMsp
+func makeAndVecs(vec data.Vector, c int) (data.Vector, data.Vector) {
+	vec1 := make(data.Vector, c+1)
+	vec2 := make(data.Vector, c+1)
+	for i := 0; i < c; i++ {
+		vec1[i] = big.NewInt(0)
+		if i < len(vec) {
+			vec2[i] = new(big.Int).Set(vec[i])
+		} else {
+			vec2[i] = big.NewInt(0)
+		}
+	}
+	vec1[c] = big.NewInt(-1)
+	vec2[c] = big.NewInt(1)
+
+	return vec1, vec2
+}
+
 // gaussianElimination solves a vector equation mat * x = v and finds vector x,
 // using Gaussian elimination. Arithmetic operations are considered to be over
 // Z_p, where p should be a prime number. If such x does not exist, then the
 // function returns an error.
 func gaussianElimination(mat data.Matrix, v data.Vector, p *big.Int) (data.Vector, error) {
+	fmt.Println(mat, v, p)
 	if len(mat) == 0 || len(mat[0]) == 0 {
 		return nil, fmt.Errorf("the matrix should not be empty")
 	}
@@ -206,11 +370,7 @@ func gaussianElimination(mat data.Matrix, v data.Vector, p *big.Int) (data.Vecto
 			}
 		}
 		if zero {
-			if u[k].Sign() != 0 {
-				return nil, fmt.Errorf("no solution")
-			} else {
-				ret[k] = big.NewInt(0)
-			}
+			ret[k] = big.NewInt(0)
 			k++
 			continue
 		}

--- a/abe/abe.go
+++ b/abe/abe.go
@@ -17,6 +17,7 @@ type abeParams struct {
 	l int      // number of attributes
 	p *big.Int // order of the elliptic curve
 }
+
 // Abe represents an ABE scheme.
 type Abe struct {
 	Params *abeParams
@@ -57,9 +58,9 @@ func (a Abe) GenerateMasterKeys() (*AbePubKey, data.Vector, error) {
 
 // AbeCipher represents a ciphertext of an ABE scheme.
 type AbeCipher struct {
-	gamma     []int // the set of attributes that can be used for policy of decryption
-	attribToI map[int]int // a map that connects the attributes in gamma with elements of e
-	e0        *bn256.GT // the first part of the encryption
+	gamma     []int         // the set of attributes that can be used for policy of decryption
+	attribToI map[int]int   // a map that connects the attributes in gamma with elements of e
+	e0        *bn256.GT     // the first part of the encryption
 	e         data.VectorG2 // the second part of the encryption
 }
 
@@ -224,9 +225,9 @@ func BooleanToMsp(boolExp string, p *big.Int) (*Msp, error) {
 
 	// create an invertible matrix that maps [1, 0,..., 0] to [1,1,...,1]
 	perm := make(data.Matrix, len(msp.mat[0]))
-	for i:=0; i < len(msp.mat[0]); i++ {
+	for i := 0; i < len(msp.mat[0]); i++ {
 		perm[i] = make(data.Vector, len(msp.mat[0]))
-		for j:=0; j < len(msp.mat[0]); j++ {
+		for j := 0; j < len(msp.mat[0]); j++ {
 			if i == 0 || j == i {
 				perm[i][j] = big.NewInt(1)
 			} else {

--- a/abe/abe.go
+++ b/abe/abe.go
@@ -1,0 +1,66 @@
+package abe
+
+import (
+	"math/big"
+	"github.com/fentec-project/gofe/sample"
+	"github.com/fentec-project/gofe/data"
+	"github.com/cloudflare/bn256"
+)
+
+type abeParams struct {
+	l     int   // number of attributes
+	p     *big.Int  // order of the elliptic curve
+}
+
+type Abe struct {
+	Params *abeParams
+}
+
+func newAbe(l int) (*Abe){
+	return &Abe{Params: &abeParams{
+		l:	l,
+		p:  bn256.Order,
+	}}
+}
+
+type AbePubKey struct {
+	t data.VectorG2
+	y *bn256.GT
+}
+
+// should we put public key into Abe struct
+func (a Abe) GenerateMasterKeys() (*AbePubKey, data.Vector, error) {
+	sampler := sample.NewUniform(a.Params.p)
+	sk, err := data.NewRandomVector(a.Params.l + 1, sampler)
+	if err != nil {
+		return nil, nil, err
+	}
+	t := sk.MulG2()
+	y := bn256.Pair(new(bn256.G1), new(bn256.G2)) // is this the same as new(bn256.GT)?
+	return &AbePubKey{t: t, y: y,}, sk, nil
+}
+
+type AbeCipher struct {
+	gamma []int
+	e0 *bn256.GT
+	e data.VectorG2
+}
+
+func (a Abe) Encrypt(msg *bn256.GT, gamma []int, pk *AbePubKey) (*AbeCipher, error) {
+	sampler := sample.NewUniform(a.Params.p)
+	s, err := sampler.Sample()
+	if err != nil {
+		return nil, err
+	}
+	e0 := new(bn256.GT).Add(msg, new(bn256.GT).ScalarMult(pk.y, s))
+	e := make(data.VectorG2, len(gamma))
+	for  i, el := range gamma {
+		e[i] = new(bn256.G2).ScalarMult(pk.t[el], s)
+	}
+
+	return &AbeCipher{gamma: gamma, e0: e0, e: e,}, nil
+}
+
+func (a Abe) KeyGen(msp data.Matrix, msk data.Vector, mpk AbePubKey) (data.VectorG1) {
+
+}

--- a/abe/abe.go
+++ b/abe/abe.go
@@ -110,7 +110,7 @@ func (a Abe) KeyGen(msp *Msp, sk data.Vector) (data.VectorG1, error) {
 	if len(msp.mat) == 0 || len(msp.mat[0]) == 0 {
 		return nil, fmt.Errorf("empty msp matrix")
 	}
-	if len(sk) != a.Params.l {
+	if len(sk) != (a.Params.l + 1) {
 		return nil, fmt.Errorf("the secret key has wrong length")
 	}
 

--- a/abe/abe.go
+++ b/abe/abe.go
@@ -5,6 +5,7 @@ import (
 	"github.com/fentec-project/gofe/sample"
 	"github.com/fentec-project/gofe/data"
 	"github.com/cloudflare/bn256"
+	"fmt"
 )
 
 type abeParams struct {
@@ -35,8 +36,9 @@ func (a Abe) GenerateMasterKeys() (*AbePubKey, data.Vector, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	t := sk.MulG2()
+	t := sk[:a.Params.l].MulG2()
 	y := bn256.Pair(new(bn256.G1), new(bn256.G2)) // is this the same as new(bn256.GT)?
+	y.ScalarMult(y, sk[a.Params.l])
 	return &AbePubKey{t: t, y: y,}, sk, nil
 }
 
@@ -61,6 +63,140 @@ func (a Abe) Encrypt(msg *bn256.GT, gamma []int, pk *AbePubKey) (*AbeCipher, err
 	return &AbeCipher{gamma: gamma, e0: e0, e: e,}, nil
 }
 
-func (a Abe) KeyGen(msp data.Matrix, msk data.Vector, mpk AbePubKey) (data.VectorG1) {
 
+type Msp struct {
+	mat data.Matrix
+	rows int
+	cols int
+	rowToI []int
+}
+
+func (a Abe) KeyGen(msp Msp, msk data.Vector, mpk AbePubKey) (data.VectorG1, error) {
+	u, err := getSum(msk[a.Params.l], a.Params.p, msp.cols)
+	if err != nil {
+		return nil, err
+	}
+	key := make(data.VectorG1, msp.rows)
+	for i := 0; i < msp.rows; i++ {
+		tMapIInv := new(big.Int).ModInverse(msk[msp.rowToI[i]], a.Params.p)
+		matTimesU, err := msp.mat[i].Dot(u)
+		if err != nil {
+			return nil, err
+		}
+		pow := new(big.Int).Mul(tMapIInv, matTimesU)
+		key[i] = new(bn256.G1).ScalarBaseMult(pow)
+	}
+
+	return key, nil
+}
+
+func getSum(y *big.Int, p *big.Int, d int) (data.Vector, error) {
+	ret := make(data.Vector, d)
+	sampler := sample.NewUniform(p)
+	var err error
+	sum := big.NewInt(0)
+	for i := 0; i < d - 1; i++ {
+		ret[i], err = sampler.Sample()
+		if err != nil {
+			return nil, err
+		}
+		sum.Add(sum, ret[i])
+		sum.Mod(sum, p)
+	}
+	ret[d-1] = new(big.Int).Sub(y, sum)
+	ret[d-1].Mod(ret[d-1], p)
+	return ret, nil
+}
+
+//func (a Abe) Decrypt(cipher *AbeCipher, key data.VectorG1, pk *AbePubKey) (bn256.GT, error) {
+//
+//}
+
+func gaussianElimination(mat data.Matrix, v data.Vector, p *big.Int) (data.Vector, error) {
+	cpMat := make([] data.Vector, len(mat))
+	u := make(data.Vector, len(mat))
+	fmt.Println(len(mat), len(mat[0]))
+	for i := 0; i < len(mat); i++ {
+		cpMat[i] = make(data.Vector, len(mat[0]))
+		for j := 0; j < len(mat[0]); j++ {
+			cpMat[i][j] = new(big.Int).Set(mat[i][j])
+		}
+		u[i] = new(big.Int).Set(v[i])
+	}
+	m, _ := data.NewMatrix(cpMat) // error is impossible to happen
+	ret := make(data.Vector, len(mat[0]))
+	h, k := 0, 0
+	for h < len(m) && k < len(m[0]) {
+		zero := true
+		for i := h; i < len(m); i++ {
+			if m[i][k].Sign() != 0 {
+				fmt.Println(h, i)
+				//fmt.Println(m)
+				m[h], m[i] = m[i], m[h]
+
+				u[h], u[i] = u[i], u[h]
+				zero = false
+				break
+			}
+		}
+		if zero {
+			if u[k].Sign() != 0 {
+				return nil, fmt.Errorf("no solution")
+			} else {
+				ret[k] = big.NewInt(0)
+			}
+			k++
+			continue
+		}
+		mHKInv := new(big.Int).ModInverse(m[h][k], p)
+		fmt.Println(mHKInv, "inv")
+		for i := h + 1; i < len(m); i++ {
+			f := new(big.Int).Mul(mHKInv, m[i][k])
+			fmt.Println(f, "f")
+			m[i][k] = big.NewInt(0)
+			for j := k + 1; j < len(m[0]); j++ {
+				fmt.Println(m[i][j], m[h][j], new(big.Int).Mul(f, m[h][j]))
+				m[i][j].Sub(m[i][j], new(big.Int).Mul(f, m[h][j]))
+				fmt.Println(m[i][j])
+				m[i][j].Mod(m[i][j], p)
+			}
+			u[i].Sub(u[i], new(big.Int).Mul(f, u[h]))
+			u[i].Mod(u[i], p)
+		}
+		fmt.Println(m)
+		k++
+		h++
+	}
+	for i := h; i < len(m); i++ {
+		if u[i].Sign() != 0 {
+			return nil, fmt.Errorf("no solution")
+		}
+	}
+	for j := k; j < len(m[0]); j++ {
+		ret[j] = big.NewInt(0)
+	}
+
+	fmt.Println(m, u)
+	//fmt.Println(h, k)
+	fmt.Println(ret)
+	for h > 0 {
+		h--
+		for k > 0 {
+			k--
+			//fmt.Println(ret[k])
+			if ret[k] == nil {
+				//fmt.Println(ret[k], 2)
+				//fmt.Println(len(m[h][k+1:]), len(ret[k+1:]))
+				tmpSum, _ := m[h][k+1:].Dot(ret[k+1:])
+				ret[k] = new(big.Int).Sub(u[h], tmpSum)
+				mHKInv := new(big.Int).ModInverse(m[h][k], p)
+				ret[k].Mul(ret[k], mHKInv)
+				ret[k].Mod(ret[k], p)
+				break
+			}
+		}
+	}
+	//fmt.Println(ret)
+
+	return ret, nil
 }

--- a/abe/abe_internal_test.go
+++ b/abe/abe_internal_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-
 func TestBooleanToMsp(t *testing.T) {
 	// create as msp struct out of a boolean expression
 	p := big.NewInt(7)

--- a/abe/abe_internal_test.go
+++ b/abe/abe_internal_test.go
@@ -1,0 +1,92 @@
+package abe
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/fentec-project/gofe/data"
+	"github.com/fentec-project/gofe/sample"
+	"github.com/stretchr/testify/assert"
+)
+
+
+func TestBooleanToMsp(t *testing.T) {
+	// create as msp struct out of a boolean expression
+	p := big.NewInt(7)
+	msp, err := BooleanToMSP("1 AND (((6 OR 7) AND (8 OR 9)) OR ((2 AND 3) OR (4 AND 5)))", p)
+	if err != nil {
+		t.Fatalf("Error while processing a boolean expression: %v", err)
+	}
+
+	// check if having attributes 1, 7 and 9 satisfies the expression, i.e. entries 0, 2, 4
+	// of a msp matrix span vector [1, 1,..., 1], using Gaussian elimination
+	v := make(data.Vector, len(msp.Mat[0]))
+	for i := 0; i < len(v); i++ {
+		v[i] = big.NewInt(1)
+	}
+	m := make(data.Matrix, 3)
+	m[0] = msp.Mat[0]
+	m[1] = msp.Mat[2]
+	m[2] = msp.Mat[4]
+
+	x, err := gaussianElimination(m.Transpose(), v, p)
+	if err != nil {
+		t.Fatalf("Error finding a vector: %v", err)
+	}
+	assert.NotNil(t, x)
+
+	// check if an error is generated if the boolean expression is not in a correct form
+	_, err = BooleanToMSP("1 AND ((6 OR 7) AND (8 OR 9)) OR ((2 AND 3) OR (4 AND 5)))", p)
+	assert.Error(t, err)
+
+}
+
+func TestGaussianElimintaion(t *testing.T) {
+	// create instances mat, xTest and v for which mat * xTest = v
+	// as a matrix vector multiplication over Z_p
+
+	p := big.NewInt(17)
+	sampler := sample.NewUniform(p)
+	mat, err := data.NewRandomMatrix(100, 50, sampler)
+	if err != nil {
+		t.Fatalf("Error during matrix generation: %v", err)
+	}
+
+	xTest, err := data.NewRandomVector(50, sampler)
+	if err != nil {
+		t.Fatalf("Error during vector generation: %v", err)
+	}
+
+	v, err := mat.MulVec(xTest)
+	if err != nil {
+		t.Fatalf("Error in generating a test vector: %v", err)
+	}
+	v = v.Mod(p)
+
+	// test the Gaussian elimination algorithm that given v and mat
+	// finds x such that mat * x = v
+	x, err := gaussianElimination(mat, v, p)
+	if err != nil {
+		t.Fatalf("Error in Gaussian elimination: %v", err)
+	}
+
+	// test if the obtained x is correct
+	vCheck, err := mat.MulVec(x)
+	if err != nil {
+		t.Fatalf("Error obtainig a check value: %v", err)
+	}
+	vCheck = vCheck.Mod(p)
+	assert.Equal(t, v, vCheck)
+
+	// test if errors are returned if the inputs have a wrong form
+	vWrong, err := data.NewRandomVector(101, sampler)
+	if err != nil {
+		t.Fatalf("Error during vector generation: %v", err)
+	}
+	_, err = gaussianElimination(mat, vWrong, p)
+	assert.Error(t, err)
+
+	matWrong := make(data.Matrix, 0)
+	_, err = gaussianElimination(matWrong, v, p)
+	assert.Error(t, err)
+}

--- a/abe/abe_test.go
+++ b/abe/abe_test.go
@@ -6,26 +6,77 @@ import (
 	"math/big"
 	"github.com/fentec-project/gofe/sample"
 	"github.com/fentec-project/gofe/data"
+	"github.com/stretchr/testify/assert"
+	"github.com/cloudflare/bn256"
 )
 
 func TestAbe(t *testing.T) {
-	a := newAbe(10)
-	fmt.Println(a)
+	l := 10
+	a := newAbe(l)
+	pubKey, sk, err := a.GenerateMasterKeys()
+	if err != nil {
+		t.Fatalf("Failed to genrate master keys: %v", err)
+	}
+	sampler := sample.NewUniform(a.Params.p)
+	exponent, err := sampler.Sample()
+	if err != nil {
+		t.Fatalf("Failed to generate random values: %v", err)
+	}
+	gamma := []int{1, 2, 3}
+	msg := new(bn256.GT).ScalarBaseMult(exponent)
+	cipher, err := a.Encrypt(msg, gamma, pubKey)
+	if err != nil {
+		t.Fatalf("Failed to encrypt: %v", err)
+	}
+
+	ones := make(data.Vector, 3)
+	for i := 0; i < len(ones); i++ {
+		ones[i] = big.NewInt(1)
+	}
+	var mat data.Matrix
+	for {
+		mat, err = data.NewRandomMatrix(3, 3, sampler)
+		_, err := gaussianElimination(mat, ones, a.Params.p)
+		if err == nil {
+			break
+		}
+	}
+
+	msp := Msp{mat: mat, rows: 3, cols: 3, rowToAttrib: []int{1, 2, 3}}
+
+	keys, err := a.KeyGen(msp, sk)
+	if err != nil {
+		t.Fatalf("Failed to generate keys: %v", err)
+	}
+
+	abeKey := a.DelagateKeys(keys, msp, gamma)
+
+	msgCheck, err := a.Decrypt(cipher, abeKey, pubKey)
+	if err != nil {
+		t.Fatalf("Failed to decrypt: %v", err)
+	}
+
+
+	fmt.Println(msg)
+	fmt.Println(msgCheck)
+
 }
 
 func TestGaussianElimintaion(t *testing.T) {
-	p := big.NewInt(5)
+	p := big.NewInt(17)
 	sampler := sample.NewUniform(p)
-	mat, err := data.NewRandomMatrix(3, 3, sampler)
+	mat, err := data.NewRandomMatrix(100, 50, sampler)
 	if err != nil {
 		t.Fatalf("Error during matrix generation: %v", err)
 	}
-	v, err := data.NewRandomVector(3, sampler)
-	fmt.Println(mat, v)
+	xCheck, err := data.NewRandomVector(50, sampler)
+	v, err := mat.MulVec(xCheck)
+	v = v.Mod(p)
+	//fmt.Println(mat, v)
 	x, err := gaussianElimination(mat, v, p)
-	fmt.Println(x)
+	//fmt.Println(x)
 	vCheck, err := mat.MulVec(x)
 	vCheck = vCheck.Mod(p)
-	//assert.Equal(t, v, vCheck)
-	fmt.Println(v, vCheck)
+	assert.Equal(t, v, vCheck)
+	//fmt.Println(v, vCheck)
 }

--- a/abe/abe_test.go
+++ b/abe/abe_test.go
@@ -1,0 +1,11 @@
+package abe
+
+import (
+	"testing"
+	"fmt"
+)
+
+func TestAbe(t *testing.T) {
+	a := newAbe(10)
+	fmt.Println(a)
+}

--- a/abe/abe_test.go
+++ b/abe/abe_test.go
@@ -23,7 +23,7 @@ func TestAbe(t *testing.T) {
 	}
 
 	// create a random message to be encrypted, for now
-	// this is an element of a elliptic curve
+	// this is an element of an elliptic curve
 	sampler := sample.NewUniform(a.Params.p)
 	exponent, err := sampler.Sample()
 	if err != nil {

--- a/abe/abe_test.go
+++ b/abe/abe_test.go
@@ -8,65 +8,78 @@ import (
 	"github.com/fentec-project/gofe/data"
 	"github.com/fentec-project/gofe/sample"
 	"github.com/stretchr/testify/assert"
-	"fmt"
 )
 
 func TestAbe(t *testing.T) {
+	// create a new ABE struct with the universe of l possible
+	// attributes (attributes are denoted by the integers in [0, l)
 	l := 10
 	a := newAbe(l)
+
+	// generate a a pubic and secret key for the scheme
 	pubKey, sk, err := a.GenerateMasterKeys()
 	if err != nil {
 		t.Fatalf("Failed to genrate master keys: %v", err)
 	}
+
+	// create a random message to be encrypted, for now
+	// this is an element of a elliptic curve
 	sampler := sample.NewUniform(a.Params.p)
 	exponent, err := sampler.Sample()
 	if err != nil {
 		t.Fatalf("Failed to generate random values: %v", err)
 	}
-	gamma := []int{1, 2, 3}
 	msg := new(bn256.GT).ScalarBaseMult(exponent)
+
+	// define a set of attributes (a subset of the universe of attributes)
+	// that are needed for the encrypted message
+	gamma := []int{0, 1, 2, 4}
+
+	// encrypt the message
 	cipher, err := a.Encrypt(msg, gamma, pubKey)
 	if err != nil {
 		t.Fatalf("Failed to encrypt: %v", err)
 	}
 
-	//ones := make(data.Vector, 3)
-	//for i := 0; i < len(ones); i++ {
-	//	ones[i] = big.NewInt(1)
-	//}
-	//var mat data.Matrix
-	//for {
-	//	mat, err = data.NewRandomMatrix(3, 3, sampler)
-	//	_, err := gaussianElimination(mat, ones, a.Params.p)
-	//	if err == nil {
-	//		break
-	//	}
-	//}
-	//
-	//msp := &Msp{mat: mat, rowToAttrib: []int{1, 2, 3}}
-	msp, err := BooleanToMsp("(1 OR 2) AND (2 OR 3)", a.Params.p)
-	fmt.Println(msp.mat)
+	// create a msp struct representing a policy of which attributes are needed
+	// to decrypt the ciphertext
+	msp, err := BooleanToMsp("(1 OR 4) AND (2 OR (0 AND 1))", a.Params.p)
 	if err != nil {
-		t.Fatalf("Failed to generate keys: %v", err)
+		t.Fatalf("Failed to generate the policy: %v", err)
 	}
 
+	// generate keys for decryption, i.e. a vector of keys, for each row in
+	// the msp matrix one ky
 	keys, err := a.KeyGen(msp, sk)
 	if err != nil {
 		t.Fatalf("Failed to generate keys: %v", err)
 	}
 
+	// test if error is returned when a bad Msp struct is given
 	emptyMsp := &Msp{mat: make(data.Matrix, 0), rowToAttrib: make([]int, 0)}
 	_, err = a.KeyGen(emptyMsp, sk)
 	assert.Error(t, err)
 
-	abeKey := a.DelagateKeys(keys, msp, gamma)
+	// produce a set of keys that are given to an entity with a set
+	// of attributes in ownedAttrib
+	ownedAttrib := []int{1, 2}
+	abeKey := a.DelagateKeys(keys, msp, ownedAttrib)
 
+	// decrypt the ciphertext with the set of delegated keys
 	msgCheck, err := a.Decrypt(cipher, abeKey)
 	if err != nil {
 		t.Fatalf("Failed to decrypt: %v", err)
 	}
-
 	assert.Equal(t, msg, msgCheck)
+
+	// produce a set of keys that are given to an entity with a set
+	// of insufficient attributes in ownedAttribInsuff
+	ownedAttribInsuff := []int{4, 0}
+	abeKeyInsuff := a.DelagateKeys(keys, msp, ownedAttribInsuff)
+
+	// try to decrypt the ciphertext with the set of delegated keys
+	msgCheck, err = a.Decrypt(cipher, abeKeyInsuff)
+	assert.Error(t, err)
 }
 
 func TestBooleanToMsp(t *testing.T) {
@@ -76,7 +89,6 @@ func TestBooleanToMsp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error while processing a boolean expression: %v", err)
 	}
-	fmt.Println(msp.mat)
 
 	// check if having attributes 1, 7 and 9 satisfies the expression, i.e. entries 0, 2, 4
 	// of a msp matrix span vector [1, 0,..., 0]
@@ -95,31 +107,41 @@ func TestBooleanToMsp(t *testing.T) {
 	}
 	assert.NotNil(t, x)
 
-	// check if an error is generated if the boolean expression is not correct
+	// check if an error is generated if the boolean expression is not in a correct form
 	_, err = BooleanToMsp("1 AND ((6 OR 7) AND (8 OR 9)) OR ((2 AND 3) OR (4 AND 5)))", p)
 	assert.Error(t, err)
 
 }
 
 func TestGaussianElimintaion(t *testing.T) {
+	// create instances mat, xTest and v for which mat * xTest = v
+	// as a matrix vector multiplication over Z_p
+
 	p := big.NewInt(17)
 	sampler := sample.NewUniform(p)
 	mat, err := data.NewRandomMatrix(100, 50, sampler)
 	if err != nil {
 		t.Fatalf("Error during matrix generation: %v", err)
 	}
-	xCheck, err := data.NewRandomVector(50, sampler)
+
+	xTest, err := data.NewRandomVector(50, sampler)
 	if err != nil {
 		t.Fatalf("Error during vector generation: %v", err)
 	}
 
-	v, err := mat.MulVec(xCheck)
+	v, err := mat.MulVec(xTest)
 	v = v.Mod(p)
+
+	// test the Gaussian elimination algorithm that given v and mat
+	// finds x such that mat * x = v
 	x, err := gaussianElimination(mat, v, p)
+
+	// test if the obtained x is correct
 	vCheck, err := mat.MulVec(x)
 	vCheck = vCheck.Mod(p)
 	assert.Equal(t, v, vCheck)
 
+	// test if errors are returned if the inputs have a wrong form
 	vWrong, err := data.NewRandomVector(101, sampler)
 	if err != nil {
 		t.Fatalf("Error during vector generation: %v", err)

--- a/abe/abe_test.go
+++ b/abe/abe_test.go
@@ -4,17 +4,17 @@ import (
 	"testing"
 
 	"github.com/cloudflare/bn256"
+	"github.com/fentec-project/gofe/abe"
 	"github.com/fentec-project/gofe/data"
 	"github.com/fentec-project/gofe/sample"
 	"github.com/stretchr/testify/assert"
-	"github.com/fentec-project/gofe/abe"
 )
 
-func TestAbe(t *testing.T) {
+func TestABE(t *testing.T) {
 	// create a new ABE struct with the universe of l possible
 	// attributes (attributes are denoted by the integers in [0, l)
 	l := 10
-	a := abe.NewAbe(l)
+	a := abe.NewABE(l)
 
 	// generate a public key and a secret key for the scheme
 	pubKey, sk, err := a.GenerateMasterKeys()

--- a/abe/abe_test.go
+++ b/abe/abe_test.go
@@ -14,7 +14,7 @@ func TestAbe(t *testing.T) {
 	// create a new ABE struct with the universe of l possible
 	// attributes (attributes are denoted by the integers in [0, l)
 	l := 10
-	a := newAbe(l)
+	a := NewAbe(l)
 
 	// generate a a pubic and a secret key for the scheme
 	pubKey, sk, err := a.GenerateMasterKeys()
@@ -43,7 +43,7 @@ func TestAbe(t *testing.T) {
 
 	// create a msp struct out of a boolean expression  representing the
 	// policy specifying which attributes are needed to decrypt the ciphertext
-	msp, err := BooleanToMsp("(1 OR 4) AND (2 OR (0 AND 1))", a.Params.p)
+	msp, err := BooleanToMSP("(1 OR 4) AND (2 OR (0 AND 1))", a.Params.p)
 	if err != nil {
 		t.Fatalf("Failed to generate the policy: %v", err)
 	}
@@ -53,20 +53,20 @@ func TestAbe(t *testing.T) {
 	// the property that a subset of keys can decrypt a message iff the
 	// corresponding rows span the vector of ones (which is equivalent to
 	// corresponding attributes satisfy the boolean expression)
-	keys, err := a.KeyGen(msp, sk)
+	keys, err := a.GeneratePolicyKeys(msp, sk)
 	if err != nil {
 		t.Fatalf("Failed to generate keys: %v", err)
 	}
 
 	// test if error is returned when a bad Msp struct is given
-	emptyMsp := &Msp{mat: make(data.Matrix, 0), rowToAttrib: make([]int, 0)}
-	_, err = a.KeyGen(emptyMsp, sk)
+	emptyMsp := &MSP{mat: make(data.Matrix, 0), rowToAttrib: make([]int, 0)}
+	_, err = a.GeneratePolicyKeys(emptyMsp, sk)
 	assert.Error(t, err)
 
 	// produce a set of keys that are given to an entity with a set
 	// of attributes in ownedAttrib
 	ownedAttrib := []int{1, 2}
-	abeKey := a.DelagateKeys(keys, msp, ownedAttrib)
+	abeKey := a.DelegateKeys(keys, msp, ownedAttrib)
 
 	// decrypt the ciphertext with the set of delegated keys
 	msgCheck, err := a.Decrypt(cipher, abeKey)
@@ -78,7 +78,7 @@ func TestAbe(t *testing.T) {
 	// produce a set of keys that are given to an entity with a set
 	// of insufficient attributes in ownedAttribInsuff
 	ownedAttribInsuff := []int{4, 0}
-	abeKeyInsuff := a.DelagateKeys(keys, msp, ownedAttribInsuff)
+	abeKeyInsuff := a.DelegateKeys(keys, msp, ownedAttribInsuff)
 
 	// try to decrypt the ciphertext with the set of delegated keys
 	msgCheck, err = a.Decrypt(cipher, abeKeyInsuff)
@@ -88,7 +88,7 @@ func TestAbe(t *testing.T) {
 func TestBooleanToMsp(t *testing.T) {
 	// create as msp struct out of a boolean expression
 	p := big.NewInt(7)
-	msp, err := BooleanToMsp("1 AND (((6 OR 7) AND (8 OR 9)) OR ((2 AND 3) OR (4 AND 5)))", p)
+	msp, err := BooleanToMSP("1 AND (((6 OR 7) AND (8 OR 9)) OR ((2 AND 3) OR (4 AND 5)))", p)
 	if err != nil {
 		t.Fatalf("Error while processing a boolean expression: %v", err)
 	}
@@ -111,7 +111,7 @@ func TestBooleanToMsp(t *testing.T) {
 	assert.NotNil(t, x)
 
 	// check if an error is generated if the boolean expression is not in a correct form
-	_, err = BooleanToMsp("1 AND ((6 OR 7) AND (8 OR 9)) OR ((2 AND 3) OR (4 AND 5)))", p)
+	_, err = BooleanToMSP("1 AND ((6 OR 7) AND (8 OR 9)) OR ((2 AND 3) OR (4 AND 5)))", p)
 	assert.Error(t, err)
 
 }

--- a/abe/abe_test.go
+++ b/abe/abe_test.go
@@ -3,9 +3,29 @@ package abe
 import (
 	"testing"
 	"fmt"
+	"math/big"
+	"github.com/fentec-project/gofe/sample"
+	"github.com/fentec-project/gofe/data"
 )
 
 func TestAbe(t *testing.T) {
 	a := newAbe(10)
 	fmt.Println(a)
+}
+
+func TestGaussianElimintaion(t *testing.T) {
+	p := big.NewInt(5)
+	sampler := sample.NewUniform(p)
+	mat, err := data.NewRandomMatrix(3, 3, sampler)
+	if err != nil {
+		t.Fatalf("Error during matrix generation: %v", err)
+	}
+	v, err := data.NewRandomVector(3, sampler)
+	fmt.Println(mat, v)
+	x, err := gaussianElimination(mat, v, p)
+	fmt.Println(x)
+	vCheck, err := mat.MulVec(x)
+	vCheck = vCheck.Mod(p)
+	//assert.Equal(t, v, vCheck)
+	fmt.Println(v, vCheck)
 }

--- a/abe/abe_test.go
+++ b/abe/abe_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/fentec-project/gofe/data"
 	"github.com/fentec-project/gofe/sample"
 	"github.com/stretchr/testify/assert"
+	"fmt"
 )
 
 func TestAbe(t *testing.T) {
@@ -29,27 +30,32 @@ func TestAbe(t *testing.T) {
 		t.Fatalf("Failed to encrypt: %v", err)
 	}
 
-	ones := make(data.Vector, 3)
-	for i := 0; i < len(ones); i++ {
-		ones[i] = big.NewInt(1)
+	//ones := make(data.Vector, 3)
+	//for i := 0; i < len(ones); i++ {
+	//	ones[i] = big.NewInt(1)
+	//}
+	//var mat data.Matrix
+	//for {
+	//	mat, err = data.NewRandomMatrix(3, 3, sampler)
+	//	_, err := gaussianElimination(mat, ones, a.Params.p)
+	//	if err == nil {
+	//		break
+	//	}
+	//}
+	//
+	//msp := &Msp{mat: mat, rowToAttrib: []int{1, 2, 3}}
+	msp, err := BooleanToMsp("(1 OR 2) AND (2 OR 3)", a.Params.p)
+	fmt.Println(msp.mat)
+	if err != nil {
+		t.Fatalf("Failed to generate keys: %v", err)
 	}
-	var mat data.Matrix
-	for {
-		mat, err = data.NewRandomMatrix(3, 3, sampler)
-		_, err := gaussianElimination(mat, ones, a.Params.p)
-		if err == nil {
-			break
-		}
-	}
-
-	msp := Msp{mat: mat, rowToAttrib: []int{1, 2, 3}}
 
 	keys, err := a.KeyGen(msp, sk)
 	if err != nil {
 		t.Fatalf("Failed to generate keys: %v", err)
 	}
 
-	emptyMsp := Msp{mat: make(data.Matrix, 0), rowToAttrib: make([]int, 0)}
+	emptyMsp := &Msp{mat: make(data.Matrix, 0), rowToAttrib: make([]int, 0)}
 	_, err = a.KeyGen(emptyMsp, sk)
 	assert.Error(t, err)
 
@@ -61,6 +67,38 @@ func TestAbe(t *testing.T) {
 	}
 
 	assert.Equal(t, msg, msgCheck)
+}
+
+func TestBooleanToMsp(t *testing.T) {
+	// create as msp struct out of a boolean expression
+	p := big.NewInt(7)
+	msp, err := BooleanToMsp("1 AND (((6 OR 7) AND (8 OR 9)) OR ((2 AND 3) OR (4 AND 5)))", p)
+	if err != nil {
+		t.Fatalf("Error while processing a boolean expression: %v", err)
+	}
+	fmt.Println(msp.mat)
+
+	// check if having attributes 1, 7 and 9 satisfies the expression, i.e. entries 0, 2, 4
+	// of a msp matrix span vector [1, 0,..., 0]
+	v := make(data.Vector, len(msp.mat[0]))
+	for i := 0; i < len(v); i++ {
+		v[i] = big.NewInt(1)
+	}
+	m := make(data.Matrix, 3)
+	m[0] = msp.mat[0]
+	m[1] = msp.mat[2]
+	m[2] = msp.mat[4]
+
+	x, err := gaussianElimination(m.Transpose(), v, p)
+	if err != nil {
+		t.Fatalf("Error finding a vector: %v", err)
+	}
+	assert.NotNil(t, x)
+
+	// check if an error is generated if the boolean expression is not correct
+	_, err = BooleanToMsp("1 AND ((6 OR 7) AND (8 OR 9)) OR ((2 AND 3) OR (4 AND 5)))", p)
+	assert.Error(t, err)
+
 }
 
 func TestGaussianElimintaion(t *testing.T) {

--- a/abe/abe_test.go
+++ b/abe/abe_test.go
@@ -1,30 +1,30 @@
-package abe
+package abe_test
 
 import (
-	"math/big"
 	"testing"
 
 	"github.com/cloudflare/bn256"
 	"github.com/fentec-project/gofe/data"
 	"github.com/fentec-project/gofe/sample"
 	"github.com/stretchr/testify/assert"
+	"github.com/fentec-project/gofe/abe"
 )
 
 func TestAbe(t *testing.T) {
 	// create a new ABE struct with the universe of l possible
 	// attributes (attributes are denoted by the integers in [0, l)
 	l := 10
-	a := NewAbe(l)
+	a := abe.NewAbe(l)
 
-	// generate a a pubic and a secret key for the scheme
+	// generate a public key and a secret key for the scheme
 	pubKey, sk, err := a.GenerateMasterKeys()
 	if err != nil {
-		t.Fatalf("Failed to genrate master keys: %v", err)
+		t.Fatalf("Failed to generate master keys: %v", err)
 	}
 
 	// create a random message to be encrypted, for now
 	// this is an element of an elliptic curve
-	sampler := sample.NewUniform(a.Params.p)
+	sampler := sample.NewUniform(a.Params.P)
 	exponent, err := sampler.Sample()
 	if err != nil {
 		t.Fatalf("Failed to generate random values: %v", err)
@@ -43,7 +43,7 @@ func TestAbe(t *testing.T) {
 
 	// create a msp struct out of a boolean expression  representing the
 	// policy specifying which attributes are needed to decrypt the ciphertext
-	msp, err := BooleanToMSP("(1 OR 4) AND (2 OR (0 AND 1))", a.Params.p)
+	msp, err := abe.BooleanToMSP("(1 OR 4) AND (2 OR (0 AND 1))", a.Params.P)
 	if err != nil {
 		t.Fatalf("Failed to generate the policy: %v", err)
 	}
@@ -59,7 +59,7 @@ func TestAbe(t *testing.T) {
 	}
 
 	// test if error is returned when a bad Msp struct is given
-	emptyMsp := &MSP{mat: make(data.Matrix, 0), rowToAttrib: make([]int, 0)}
+	emptyMsp := &abe.MSP{Mat: make(data.Matrix, 0), RowToAttrib: make([]int, 0)}
 	_, err = a.GeneratePolicyKeys(emptyMsp, sk)
 	assert.Error(t, err)
 
@@ -82,77 +82,5 @@ func TestAbe(t *testing.T) {
 
 	// try to decrypt the ciphertext with the set of delegated keys
 	msgCheck, err = a.Decrypt(cipher, abeKeyInsuff)
-	assert.Error(t, err)
-}
-
-func TestBooleanToMsp(t *testing.T) {
-	// create as msp struct out of a boolean expression
-	p := big.NewInt(7)
-	msp, err := BooleanToMSP("1 AND (((6 OR 7) AND (8 OR 9)) OR ((2 AND 3) OR (4 AND 5)))", p)
-	if err != nil {
-		t.Fatalf("Error while processing a boolean expression: %v", err)
-	}
-
-	// check if having attributes 1, 7 and 9 satisfies the expression, i.e. entries 0, 2, 4
-	// of a msp matrix span vector [1, 1,..., 1], using Gaussian elimination
-	v := make(data.Vector, len(msp.mat[0]))
-	for i := 0; i < len(v); i++ {
-		v[i] = big.NewInt(1)
-	}
-	m := make(data.Matrix, 3)
-	m[0] = msp.mat[0]
-	m[1] = msp.mat[2]
-	m[2] = msp.mat[4]
-
-	x, err := gaussianElimination(m.Transpose(), v, p)
-	if err != nil {
-		t.Fatalf("Error finding a vector: %v", err)
-	}
-	assert.NotNil(t, x)
-
-	// check if an error is generated if the boolean expression is not in a correct form
-	_, err = BooleanToMSP("1 AND ((6 OR 7) AND (8 OR 9)) OR ((2 AND 3) OR (4 AND 5)))", p)
-	assert.Error(t, err)
-
-}
-
-func TestGaussianElimintaion(t *testing.T) {
-	// create instances mat, xTest and v for which mat * xTest = v
-	// as a matrix vector multiplication over Z_p
-
-	p := big.NewInt(17)
-	sampler := sample.NewUniform(p)
-	mat, err := data.NewRandomMatrix(100, 50, sampler)
-	if err != nil {
-		t.Fatalf("Error during matrix generation: %v", err)
-	}
-
-	xTest, err := data.NewRandomVector(50, sampler)
-	if err != nil {
-		t.Fatalf("Error during vector generation: %v", err)
-	}
-
-	v, err := mat.MulVec(xTest)
-	v = v.Mod(p)
-
-	// test the Gaussian elimination algorithm that given v and mat
-	// finds x such that mat * x = v
-	x, err := gaussianElimination(mat, v, p)
-
-	// test if the obtained x is correct
-	vCheck, err := mat.MulVec(x)
-	vCheck = vCheck.Mod(p)
-	assert.Equal(t, v, vCheck)
-
-	// test if errors are returned if the inputs have a wrong form
-	vWrong, err := data.NewRandomVector(101, sampler)
-	if err != nil {
-		t.Fatalf("Error during vector generation: %v", err)
-	}
-	_, err = gaussianElimination(mat, vWrong, p)
-	assert.Error(t, err)
-
-	matWrong := make(data.Matrix, 0)
-	_, err = gaussianElimination(matWrong, v, p)
 	assert.Error(t, err)
 }

--- a/abe/abe_test.go
+++ b/abe/abe_test.go
@@ -49,7 +49,7 @@ func TestAbe(t *testing.T) {
 	}
 
 	// generate keys for decryption, i.e. a vector of keys, for each row in
-	// the msp matrix one ky
+	// the msp matrix one key
 	keys, err := a.KeyGen(msp, sk)
 	if err != nil {
 		t.Fatalf("Failed to generate keys: %v", err)

--- a/innerprod/fullysec/dmcfe.go
+++ b/innerprod/fullysec/dmcfe.go
@@ -18,8 +18,9 @@ package fullysec
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"math/big"
+
+	"github.com/pkg/errors"
 
 	"github.com/cloudflare/bn256"
 	"github.com/fentec-project/gofe/data"
@@ -52,8 +53,8 @@ func NewDMCFEClient(idx int, t data.Matrix) (*DMCFEClient, error) {
 
 	return &DMCFEClient{
 		Idx: idx,
-		t:     t,
-		s:     s,
+		t:   t,
+		s:   s,
 	}, nil
 }
 
@@ -123,14 +124,14 @@ func NewDMCFEDecryptor(y data.Vector, label string, ciphers []*bn256.G1, keyShar
 	}
 
 	return &DMCFEDecryptor{
-		y:           y,
-		label:       label,
-		ciphers: ciphers,
-		key1:        key1,
-		key2:        key2,
-		bound: bound,
-		gCalc:       dlog.NewCalc().InBN256(),
-		gInvCalc:    dlog.NewCalc().InBN256(),
+		y:        y,
+		label:    label,
+		ciphers:  ciphers,
+		key1:     key1,
+		key2:     key2,
+		bound:    bound,
+		gCalc:    dlog.NewCalc().InBN256(),
+		gInvCalc: dlog.NewCalc().InBN256(),
 	}
 }
 

--- a/innerprod/fullysec/dmcfe_test.go
+++ b/innerprod/fullysec/dmcfe_test.go
@@ -20,11 +20,11 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/cloudflare/bn256"
 	"github.com/fentec-project/gofe/data"
+	"github.com/fentec-project/gofe/innerprod/fullysec"
 	"github.com/fentec-project/gofe/sample"
 	"github.com/stretchr/testify/assert"
-	"github.com/cloudflare/bn256"
-	"github.com/fentec-project/gofe/innerprod/fullysec"
 )
 
 func Test_DMCFE(t *testing.T) {

--- a/innerprod/simple/ringlwe.go
+++ b/innerprod/simple/ringlwe.go
@@ -168,6 +168,7 @@ func (s *RingLWE) DeriveKey(y data.Vector, SK data.Matrix) (data.Vector, error) 
 
 	return skY, nil
 }
+
 // Encrypt encrypts matrix X using public key PK.
 // It returns the resulting ciphertext matrix. In case of malformed
 // public key or input matrix that violates the configured bound,

--- a/innerprod/simple/ringlwe.go
+++ b/innerprod/simple/ringlwe.go
@@ -168,7 +168,6 @@ func (s *RingLWE) DeriveKey(y data.Vector, SK data.Matrix) (data.Vector, error) 
 
 	return skY, nil
 }
-
 // Encrypt encrypts matrix X using public key PK.
 // It returns the resulting ciphertext matrix. In case of malformed
 // public key or input matrix that violates the configured bound,


### PR DESCRIPTION
ABE schemes provide a functionality that an entity can decrypt a ciphertext if and only if he or she possesses sufficient set of attributes.
This PR implements a key policy (KP) ABE scheme presented in [this paper](https://eprint.iacr.org/2006/309.pdf). It is based on a monotone span programs (MSP) providing a policy for the decryption. It includes the following functionalities:
- encryption of a message with only specifying which set of attributes will be important for decryption policy
- a policy convertor that transforms a boolean formula expressing the policy which attributes are needed for the decryption into an equivalent MSP structure
- key derivation that given given a MSP structure creates a set of keys corresponding to attributes
- key delegation that delegates the above keys to entities with some attributes
- decryption that based on given keys decrypts or denies the user

As a part of the decryption process a helping function solving a matrix vector equation Ax = v is implemented using Gaussian elimination.