### PR TITLE
Dlog improvement

### DIFF
--- a/internal/dlog/calc.go
+++ b/internal/dlog/calc.go
@@ -419,7 +419,6 @@ func (c *CalcBN256) runBabyStepGiantStepIterative(h, g *bn256.GT, retChan chan *
 			y.Add(y, z)
 		}
 		z.Add(z, z)
-
 	}
 
 	retChan <- nil

--- a/internal/dlog/calc.go
+++ b/internal/dlog/calc.go
@@ -134,7 +134,7 @@ func (c *CalcZp) BabyStepGiantStep(h, g *big.Int) (*big.Int, error) {
 		ret.Neg(ret)
 	}
 
-	return ret, err
+	return ret, nil
 }
 
 // runBabyStepGiantStep implements the baby-step giant-step method to
@@ -290,7 +290,7 @@ func (c *CalcBN256) precompute(g *bn256.GT) {
 	c.Precomp = T
 }
 
-// BabyStepGiantStepStand implements the baby-step giant-step method to
+// BabyStepGiantStepStd implements the baby-step giant-step method to
 // compute the discrete logarithm in the BN256.GT group.
 //
 // It searches for a solution <= bound. If bound argument is nil,
@@ -299,7 +299,7 @@ func (c *CalcBN256) precompute(g *bn256.GT) {
 // The function returns x, where h = g^x in BN256.GT group where operations
 // are written as multiplications. If the solution was not found
 // within the provided bound, it returns an error.
-func (c *CalcBN256) BabyStepGiantStepStand(h, g *bn256.GT) (*big.Int, error) {
+func (c *CalcBN256) BabyStepGiantStepStd(h, g *bn256.GT) (*big.Int, error) {
 	one := big.NewInt(1)
 
 	if c.Precomp == nil {
@@ -364,7 +364,7 @@ func (c *CalcBN256) BabyStepGiantStep(h, g *bn256.GT) (*big.Int, error) {
 		ret.Neg(ret)
 	}
 
-	return ret, err
+	return ret, nil
 }
 
 // runBabyStepGiantStepIterative implements the baby-step giant-step method to
@@ -380,7 +380,7 @@ func (c *CalcBN256) runBabyStepGiantStepIterative(h, g *bn256.GT, retChan chan *
 	one := big.NewInt(1)
 	two := big.NewInt(2)
 
-	// bn256.GT cannot be a key, thus we use a stringified bytes representation of the integer
+	// bn256.GT cannot be a key, thus we use a stringified representation of the struct
 	T := make(map[string]*big.Int)
 	// prepare values for the loop
 	x := new(bn256.GT).ScalarBaseMult(big.NewInt(0))

--- a/internal/dlog/calc_test.go
+++ b/internal/dlog/calc_test.go
@@ -90,7 +90,7 @@ func TestCalcBN256_BabyStepGiantStep(t *testing.T) {
 		h.Neg(h)
 	}
 
-	calc := NewCalc().InBN256().WithBound(bound)
+	calc := NewCalc().InBN256().WithBound(bound).WithNeg()
 	x, err := calc.BabyStepGiantStep(h, g)
 	if err != nil {
 		t.Fatalf("Error in baby step - giant step algorithm: %v", err)

--- a/internal/dlog/calc_test.go
+++ b/internal/dlog/calc_test.go
@@ -35,7 +35,6 @@ func TestCalcZp_BabyStepGiantStep_ElGamal(t *testing.T) {
 		t.Fatalf("Error in ElGamal key generation: %v", err)
 	}
 
-	//order := new(big.Int).Sub(key.P, big.NewInt(1))
 	bound := big.NewInt(100000000)
 
 	// first test when x is positive

--- a/internal/dlog/calc_test.go
+++ b/internal/dlog/calc_test.go
@@ -86,15 +86,13 @@ func TestCalcBN256_BabyStepGiantStep(t *testing.T) {
 		t.Fatalf("error when generating random number: %v", err)
 	}
 
-	g1gen := new(bn256.G1).ScalarBaseMult(big.NewInt(1))
-	g2gen := new(bn256.G2).ScalarBaseMult(big.NewInt(1))
-	g := bn256.Pair(g1gen, g2gen)
-	var h *bn256.GT
+	g := new(bn256.GT).ScalarBaseMult(big.NewInt(1))
+	h := new(bn256.GT)
 	if xCheck.Sign() == 1 {
-		h = new(bn256.GT).ScalarMult(g, xCheck)
+		h.ScalarMult(g, xCheck)
 	} else {
 		xCheckNeg := new(big.Int).Neg(xCheck)
-		h = new(bn256.GT).ScalarMult(g, xCheckNeg)
+		h.ScalarMult(g, xCheckNeg)
 		h.Neg(h)
 	}
 

--- a/internal/dlog/calc_test.go
+++ b/internal/dlog/calc_test.go
@@ -21,10 +21,10 @@ import (
 	"testing"
 
 	"github.com/cloudflare/bn256"
+	"github.com/fentec-project/gofe/internal"
 	"github.com/fentec-project/gofe/internal/keygen"
 	"github.com/stretchr/testify/assert"
-	emmy "github.com/xlab-si/emmy/crypto/common"
-	"github.com/fentec-project/gofe/internal"
+	"github.com/fentec-project/gofe/sample"
 )
 
 func TestCalcZp_BabyStepGiantStep_ElGamal(t *testing.T) {
@@ -36,10 +36,11 @@ func TestCalcZp_BabyStepGiantStep_ElGamal(t *testing.T) {
 	}
 
 	//order := new(big.Int).Sub(key.P, big.NewInt(1))
-	bound := big.NewInt(1000000000)
+	bound := big.NewInt(100000000)
 
 	// first test when x is positive
-	xCheck, err := emmy.GetRandomIntFromRange(big.NewInt(2), bound)
+	sampler := sample.NewUniformRange(big.NewInt(2), bound)
+	xCheck, err := sampler.Sample()
 	if err != nil {
 		t.Fatalf("Error during random int generation: %v", err)
 	}
@@ -59,7 +60,8 @@ func TestCalcZp_BabyStepGiantStep_ElGamal(t *testing.T) {
 	assert.Equal(t, xCheck, x, "BabyStepGiantStep result is wrong")
 
 	// second test when the answer can also be negative
-	xCheck, err = emmy.GetRandomIntFromRange(new(big.Int).Neg(bound), bound)
+	sampler = sample.NewUniformRange(new(big.Int).Neg(bound), bound)
+	xCheck, err = sampler.Sample()
 	if err != nil {
 		t.Fatalf("Error during random int generation: %v", err)
 	}
@@ -76,8 +78,15 @@ func TestCalcZp_BabyStepGiantStep_ElGamal(t *testing.T) {
 }
 
 func TestCalcBN256_BabyStepGiantStep(t *testing.T) {
-	xCheck := big.NewInt(99999999)
+
 	bound := big.NewInt(100000000)
+	sampler := sample.NewUniformRange(new(big.Int).Neg(bound), bound)
+
+	xCheck, err := sampler.Sample()
+	if err != nil {
+		t.Fatalf("error when generating random number: %v", err)
+	}
+
 	g1gen := new(bn256.G1).ScalarBaseMult(big.NewInt(1))
 	g2gen := new(bn256.G2).ScalarBaseMult(big.NewInt(1))
 	g := bn256.Pair(g1gen, g2gen)

--- a/internal/dlog/calc_test.go
+++ b/internal/dlog/calc_test.go
@@ -76,12 +76,19 @@ func TestCalcZp_BabyStepGiantStep_ElGamal(t *testing.T) {
 }
 
 func TestCalcBN256_BabyStepGiantStep(t *testing.T) {
-	xCheck := big.NewInt(10000000)
-	bound := big.NewInt(10000000)
+	xCheck := big.NewInt(99999999)
+	bound := big.NewInt(100000000)
 	g1gen := new(bn256.G1).ScalarBaseMult(big.NewInt(1))
 	g2gen := new(bn256.G2).ScalarBaseMult(big.NewInt(1))
 	g := bn256.Pair(g1gen, g2gen)
-	h := new(bn256.GT).ScalarMult(g, xCheck)
+	var h *bn256.GT
+	if xCheck.Sign() == 1 {
+		h = new(bn256.GT).ScalarMult(g, xCheck)
+	} else {
+		xCheckNeg := new(big.Int).Neg(xCheck)
+		h = new(bn256.GT).ScalarMult(g, xCheckNeg)
+		h.Neg(h)
+	}
 
 	calc := NewCalc().InBN256().WithBound(bound)
 	x, err := calc.BabyStepGiantStep(h, g)

--- a/internal/dlog/calc_test.go
+++ b/internal/dlog/calc_test.go
@@ -21,14 +21,14 @@ import (
 	"testing"
 
 	"github.com/cloudflare/bn256"
-	"github.com/fentec-project/gofe/internal"
 	"github.com/fentec-project/gofe/internal/keygen"
 	"github.com/stretchr/testify/assert"
 	emmy "github.com/xlab-si/emmy/crypto/common"
+	"github.com/fentec-project/gofe/internal"
 )
 
 func TestCalcZp_BabyStepGiantStep_ElGamal(t *testing.T) {
-	modulusLength := 44
+	modulusLength := 128
 
 	key, err := keygen.NewElGamal(modulusLength)
 	if err != nil {
@@ -36,7 +36,7 @@ func TestCalcZp_BabyStepGiantStep_ElGamal(t *testing.T) {
 	}
 
 	//order := new(big.Int).Sub(key.P, big.NewInt(1))
-	bound := new(big.Int).Sqrt(key.P)
+	bound := big.NewInt(1000000000)
 
 	// first test when x is positive
 	xCheck, err := emmy.GetRandomIntFromRange(big.NewInt(2), bound)

--- a/quadratic/sgp.go
+++ b/quadratic/sgp.go
@@ -225,7 +225,5 @@ func (q *SGP) Decrypt(c *SGPCipher, key *bn256.G2, F data.Matrix) (*big.Int, err
 	n2 := new(big.Int).Exp(big.NewInt(int64(q.N)), big.NewInt(2), nil)
 	b := new(big.Int).Mul(n2, b3)
 
-	d, err := q.gCalc.WithBound(b).WithNeg().BabyStepGiantStep(prod, g)
-
-	return d, err
+	return q.gCalc.WithBound(b).WithNeg().BabyStepGiantStep(prod, g)
 }

--- a/quadratic/sgp.go
+++ b/quadratic/sgp.go
@@ -225,16 +225,7 @@ func (q *SGP) Decrypt(c *SGPCipher, key *bn256.G2, F data.Matrix) (*big.Int, err
 	n2 := new(big.Int).Exp(big.NewInt(int64(q.N)), big.NewInt(2), nil)
 	b := new(big.Int).Mul(n2, b3)
 
-	var d *big.Int // d is decryption
 	d, err := q.gCalc.WithBound(b).BabyStepGiantStep(prod, g)
-	if err != nil {
-		gInv := new(bn256.GT).Neg(g)
-		d, err = q.gInvCalc.WithBound(b).BabyStepGiantStep(prod, gInv)
-		if err != nil {
-			return nil, err
-		}
-		d.Neg(d)
-	}
 
-	return d, nil
+	return d, err
 }

--- a/quadratic/sgp.go
+++ b/quadratic/sgp.go
@@ -225,7 +225,7 @@ func (q *SGP) Decrypt(c *SGPCipher, key *bn256.G2, F data.Matrix) (*big.Int, err
 	n2 := new(big.Int).Exp(big.NewInt(int64(q.N)), big.NewInt(2), nil)
 	b := new(big.Int).Mul(n2, b3)
 
-	d, err := q.gCalc.WithBound(b).BabyStepGiantStep(prod, g)
+	d, err := q.gCalc.WithBound(b).WithNeg().BabyStepGiantStep(prod, g)
 
 	return d, err
 }

--- a/quadratic/sgp_test.go
+++ b/quadratic/sgp_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestSGP(t *testing.T) {
 	bound := big.NewInt(1000)
-	sampler := sample.NewUniform(bound)
+	sampler := sample.NewUniformRange(new(big.Int).Neg(bound), bound)
 	n := 2
 	f, err := data.NewRandomMatrix(n, n, sampler)
 	if err != nil {


### PR DESCRIPTION
This pull request introduces a new version of the baby-step giant-step algorithm for calculating the discrete logarithm in Z_p and bn256 group. It is designed in a way that the algorithm prefers finding a smaller solution for a minimal additional computations. On average the computational complexity is comparable with the standard baby-step giant-step algorithm, in the worst case when the solution is close to the bound the complexity is less than doubled than the standard version, but for may practical cases when the bound is much greater than the expected solution it performs much faster. This is particularly useful for the quadratic and inner-product schemes, where the bound is put quite high due to the theoretical bounds.
This pull request also adds:
- parallel version for computing discrete log in bn256
- small changes in testing discrete logarithms avoiding the usage of library emmy