### PR TITLE
Remove appends where possible, preallocate slices, fix linter issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
 
       - run:
           name: Get dependencies
-          command: go get -u -t -v ./...
+          command: go get -t -v ./...
 
       - run:
           name: Run tests

--- a/abe/fame.go
+++ b/abe/fame.go
@@ -303,7 +303,7 @@ func (a *FAME) Decrypt(cipher *FAMECipher, key *FAMEAttribKeys, pk *FAMEPubKey) 
 	countAttrib := 0
 	for i := 0; i < len(cipher.msp.Mat); i++ {
 		if attribMap[cipher.msp.RowToAttrib[i]] {
-			countAttrib += 1
+			countAttrib++
 		}
 	}
 
@@ -317,7 +317,7 @@ func (a *FAME) Decrypt(cipher *FAMECipher, key *FAMEAttribKeys, pk *FAMEPubKey) 
 			preMatForKey[countAttrib] = cipher.msp.Mat[i]
 			ctForKey[countAttrib] = cipher.ct[i]
 			rowToAttrib[countAttrib] = cipher.msp.RowToAttrib[i]
-			countAttrib += 1
+			countAttrib++
 		}
 	}
 

--- a/abe/gpsw.go
+++ b/abe/gpsw.go
@@ -199,7 +199,7 @@ func (a *GPSW) DelegateKeys(keys data.VectorG1, msp *MSP, attrib []int) *GPSWKey
 	countAttrib := 0
 	for i := 0; i < len(msp.Mat); i++ {
 		if attribMap[msp.RowToAttrib[i]] {
-			countAttrib += 1
+			countAttrib++
 		}
 	}
 

--- a/abe/gpsw.go
+++ b/abe/gpsw.go
@@ -195,14 +195,24 @@ func (a *GPSW) DelegateKeys(keys data.VectorG1, msp *MSP, attrib []int) *GPSWKey
 	for _, e := range attrib {
 		attribMap[e] = true
 	}
-	mat := make([]data.Vector, 0)
-	d := make(data.VectorG1, 0)
-	rowToAttrib := make([]int, 0)
+
+	countAttrib := 0
 	for i := 0; i < len(msp.Mat); i++ {
 		if attribMap[msp.RowToAttrib[i]] {
-			mat = append(mat, msp.Mat[i])
-			d = append(d, keys[i])
-			rowToAttrib = append(rowToAttrib, msp.RowToAttrib[i])
+			countAttrib += 1
+		}
+	}
+
+	mat := make([]data.Vector, countAttrib)
+	d := make(data.VectorG1, countAttrib)
+	rowToAttrib := make([]int, countAttrib)
+	countAttrib = 0
+	for i := 0; i < len(msp.Mat); i++ {
+		if attribMap[msp.RowToAttrib[i]] {
+			mat[countAttrib] = msp.Mat[i]
+			d[countAttrib] = keys[i]
+			rowToAttrib[countAttrib] = msp.RowToAttrib[i]
+			countAttrib++
 		}
 	}
 

--- a/data/matrix.go
+++ b/data/matrix.go
@@ -35,17 +35,16 @@ type Matrix []Vector
 // It returns error if not all the vectors have the same number of elements.
 func NewMatrix(vectors []Vector) (Matrix, error) {
 	l := -1
-	newVectors := make([]Vector, 0)
+	newVectors := make([]Vector, len(vectors))
 
 	if len(vectors) > 0 {
 		l = len(vectors[0])
 	}
-	for _, v := range vectors {
+	for i, v := range vectors {
 		if len(v) != l {
 			return nil, fmt.Errorf("all vectors should be of the same length")
 		}
-		vector := NewVector(v)
-		newVectors = append(newVectors, vector)
+		newVectors[i] = NewVector(v)
 	}
 
 	return Matrix(newVectors), nil
@@ -164,10 +163,10 @@ func (m Matrix) Mod(modulo *big.Int) Matrix {
 // Apply applies an element-wise function f to matrix m.
 // The result is returned in a new Matrix.
 func (m Matrix) Apply(f func(*big.Int) *big.Int) Matrix {
-	res := Matrix{}
+	res := make(Matrix, len(m))
 
-	for _, vi := range m {
-		res = append(res, vi.Apply(f))
+	for i, vi := range m {
+		res[i] = vi.Apply(f)
 	}
 
 	return res
@@ -303,7 +302,7 @@ func (m Matrix) Minor(i int, j int) (Matrix, error) {
 		if k == i {
 			continue
 		}
-		vec := make(Vector, 0)
+		vec := make(Vector, 0, len(m[0])-1)
 		vec = append(vec, m[k][:j]...)
 		vec = append(vec, m[k][j+1:]...)
 		if k < i {
@@ -357,7 +356,7 @@ func (m Matrix) InverseMod(p *big.Int) (Matrix, error) {
 	if det.Cmp(big.NewInt(0)) == 0 {
 		return nil, fmt.Errorf("matrix non-invertable")
 	}
-	inv_det := new(big.Int).ModInverse(det, p)
+	invDet := new(big.Int).ModInverse(det, p)
 	sign := new(big.Int)
 	minusOne := big.NewInt(-1)
 	for i := 0; i < m.Rows(); i++ {
@@ -374,7 +373,7 @@ func (m Matrix) InverseMod(p *big.Int) (Matrix, error) {
 			value.Mod(value, p)
 			sign.Exp(minusOne, big.NewInt(int64(i+j)), nil)
 			value.Mul(value, sign)
-			value.Mul(value, inv_det)
+			value.Mul(value, invDet)
 			value.Mod(value, p)
 			row[j] = value
 		}

--- a/data/matrix.go
+++ b/data/matrix.go
@@ -122,9 +122,9 @@ func (m Matrix) Transpose() Matrix {
 		transposed[i], _ = m.GetCol(i)
 	}
 
-	m_t, _ := NewMatrix(transposed)
+	mT, _ := NewMatrix(transposed)
 
-	return m_t
+	return mT
 }
 
 // CheckBound checks whether all matrix elements are strictly
@@ -146,7 +146,7 @@ func (m Matrix) CheckDims(rows, cols int) bool {
 	return m.Rows() == rows && m.Cols() == cols
 }
 
-// mod applies the element-wise modulo operation on matrix m.
+// Mod applies the element-wise modulo operation on matrix m.
 // The result is returned in a new Matrix.
 func (m Matrix) Mod(modulo *big.Int) Matrix {
 	vectors := make([]Vector, m.Rows())
@@ -242,8 +242,8 @@ func (m Matrix) Mul(other Matrix) (Matrix, error) {
 	for i := 0; i < m.Rows(); i++ {  // po vrsticah od m
 		prod[i] = make([]*big.Int, other.Cols())
 		for j := 0; j < other.Cols(); j++ {
-			other_col, _ := other.GetCol(j)
-			prod[i][j], _ = m[i].Dot(other_col)
+			otherCol, _ := other.GetCol(j)
+			prod[i][j], _ = m[i].Dot(otherCol)
 		}
 	}
 

--- a/data/vector.go
+++ b/data/vector.go
@@ -71,7 +71,7 @@ func (v Vector) MulScalar(x *big.Int) Vector {
 	return res
 }
 
-// mod performs modulo operation on vector's elements.
+// Mod performs modulo operation on vector's elements.
 // The result is returned in a new Vector.
 func (v Vector) Mod(modulo *big.Int) Vector {
 	newCoords := make([]*big.Int, len(v))
@@ -190,7 +190,7 @@ func (v Vector) MulAsPolyInRing(other Vector) (Vector, error) {
 // VectorG1 instance.
 func (v Vector) MulG1() VectorG1 {
 	prod := make(VectorG1, len(v))
-	for i, _ := range prod {
+	for i := range prod {
 		prod[i] = new(bn256.G1).ScalarBaseMult(v[i])
 	}
 
@@ -204,7 +204,7 @@ func (v Vector) MulVecG1(g1 VectorG1) VectorG1 {
 	zero := big.NewInt(0)
 
 	prod := make(VectorG1, len(v))
-	for i, _ := range prod {
+	for i := range prod {
 		vi := new(big.Int).Set(v[i])
 		g1i := new(bn256.G1).Set(g1[i])
 		if vi.Cmp(zero) == -1 {
@@ -222,7 +222,7 @@ func (v Vector) MulVecG1(g1 VectorG1) VectorG1 {
 // VectorG2 instance.
 func (v Vector) MulG2() VectorG2 {
 	prod := make(VectorG2, len(v))
-	for i, _ := range prod {
+	for i := range prod {
 		prod[i] = new(bn256.G2).ScalarBaseMult(v[i])
 	}
 
@@ -236,7 +236,7 @@ func (v Vector) MulVecG2(g2 VectorG2) VectorG2 {
 	zero := big.NewInt(0)
 
 	prod := make(VectorG2, len(v))
-	for i, _ := range prod {
+	for i := range prod {
 		vi := new(big.Int).Set(v[i])
 		g2i := new(bn256.G2).Set(g2[i])
 		if vi.Cmp(zero) == -1 {

--- a/data/vector.go
+++ b/data/vector.go
@@ -63,9 +63,9 @@ func NewConstantVector(len int, c *big.Int) Vector {
 // MulScalar multiplies vector v by a given scalar x.
 // The result is returned in a new Vector.
 func (v Vector) MulScalar(x *big.Int) Vector {
-	res := Vector{}
-	for _, vi := range v {
-		res = append(res, new(big.Int).Mul(x, vi))
+	res := make(Vector, len(v))
+	for i, vi := range v {
+		res[i] = new(big.Int).Mul(x, vi)
 	}
 
 	return res
@@ -101,10 +101,10 @@ func (v Vector) CheckBound(bound *big.Int) error {
 // Apply applies an element-wise function f to vector v.
 // The result is returned in a new Vector.
 func (v Vector) Apply(f func(*big.Int) *big.Int) Vector {
-	res := Vector{}
+	res := make(Vector, len(v))
 
-	for _, vi := range v {
-		res = append(res, f(vi))
+	for i, vi := range v {
+		res[i] = f(vi)
 	}
 
 	return res

--- a/data/vector_bn256.go
+++ b/data/vector_bn256.go
@@ -29,7 +29,7 @@ type VectorG1 []*bn256.G1
 // It returns the result in a new VectorG1 instance.
 func (v VectorG1) Add(other VectorG1) VectorG1 {
 	sum := make(VectorG1, len(v))
-	for i, _ := range sum {
+	for i := range sum {
 		sum[i] = new(bn256.G1).Add(v[i], other[i])
 	}
 
@@ -45,7 +45,7 @@ type VectorG2 []*bn256.G2
 // It returns the result in a new VectorG2 instance.
 func (v VectorG2) Add(other VectorG2) VectorG2 {
 	sum := make(VectorG2, len(v))
-	for i, _ := range sum {
+	for i := range sum {
 		sum[i] = new(bn256.G2).Add(v[i], other[i])
 	}
 

--- a/innerprod/fullysec/dmcfe.go
+++ b/innerprod/fullysec/dmcfe.go
@@ -72,11 +72,10 @@ func (c *DMCFEClient) Encrypt(x *big.Int, label string) (*bn256.G1, error) {
 
 // GenerateKeyShare generates client's key share. Decryptor needs shares from all clients.
 func (c *DMCFEClient) GenerateKeyShare(y data.Vector) (data.VectorG2, error) {
-	var yRepr []byte
-	for i := 0; i < len(y); i++ {
-		yRepr = append(yRepr, y[i].Bytes()...)
-		yiAbs := new(big.Int).Abs(y[i])
-		if yiAbs.Cmp(y[i]) == 0 {
+	yRepr := make([]byte, 0, len(y))
+	for _, yi := range y {
+		yRepr = append(yRepr, yi.Bytes()...)
+		if yi.Sign() == 1 {
 			yRepr = append(yRepr, 1)
 		} else {
 			yRepr = append(yRepr, 2)

--- a/innerprod/fullysec/dmcfe.go
+++ b/innerprod/fullysec/dmcfe.go
@@ -72,7 +72,13 @@ func (c *DMCFEClient) Encrypt(x *big.Int, label string) (*bn256.G1, error) {
 
 // GenerateKeyShare generates client's key share. Decryptor needs shares from all clients.
 func (c *DMCFEClient) GenerateKeyShare(y data.Vector) (data.VectorG2, error) {
-	yRepr := make([]byte, 0, len(y))
+	yReprCap := 0
+	for _, yi := range y {
+		yReprCap += len(yi.Bytes())
+	}
+	yReprCap += len(y)
+
+	yRepr := make([]byte, 0, yReprCap)
 	for _, yi := range y {
 		yRepr = append(yRepr, yi.Bytes()...)
 		if yi.Sign() == 1 {

--- a/internal/dlog/pollard_rho.go
+++ b/internal/dlog/pollard_rho.go
@@ -237,7 +237,7 @@ func pollardRhoFactorization(n, B *big.Int) (map[string]int, error) {
 
 			stringified := string(i.Bytes())
 			if _, ok := factors[stringified]; ok {
-				factors[stringified] += 1
+				factors[stringified]++
 			} else {
 				factors[stringified] = 1
 			}
@@ -292,7 +292,7 @@ func runCycle(n, x *big.Int) *big.Int {
 			x.Mod(new(big.Int).Add(new(big.Int).Mul(x, x), one), n)
 			absDiff := new(big.Int).Abs(new(big.Int).Sub(x, xFixed))
 			factor.GCD(nil, nil, absDiff, n)
-			count += 1
+			count++
 		}
 
 		cycleSize *= 2

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -17,14 +17,13 @@
 package internal
 
 import (
-	"errors"
 	"fmt"
 )
 
 var malformedStr = "is not of the proper form"
 
-var MalformedPubKey = errors.New(fmt.Sprintf("public key %s", malformedStr))
-var MalformedSecKey = errors.New(fmt.Sprintf("secret key %s", malformedStr))
-var MalformedDecKey = errors.New(fmt.Sprintf("decryption key %s", malformedStr))
-var MalformedCipher = errors.New(fmt.Sprintf("ciphertext %s", malformedStr))
-var MalformedInput = errors.New(fmt.Sprintf("input data %s", malformedStr))
+var MalformedPubKey = fmt.Errorf("public key %s", malformedStr)
+var MalformedSecKey = fmt.Errorf("secret key %s", malformedStr)
+var MalformedDecKey = fmt.Errorf("decryption key %s", malformedStr)
+var MalformedCipher = fmt.Errorf("ciphertext %s", malformedStr)
+var MalformedInput = fmt.Errorf("input data %s", malformedStr)

--- a/quadratic/sgp.go
+++ b/quadratic/sgp.go
@@ -153,8 +153,8 @@ func (q *SGP) Encrypt(x, y data.Vector, msk *SGPSecKey) (*SGPCipher, error) {
 		a[i] = ai
 
 		// v = (y_i, -t_i)
-		t_iNeg := new(big.Int).Sub(q.mod, msk.T[i])
-		bi, err := W.MulVec(data.NewVector([]*big.Int{y[i], t_iNeg}))
+		tiNeg := new(big.Int).Sub(q.mod, msk.T[i])
+		bi, err := W.MulVec(data.NewVector([]*big.Int{y[i], tiNeg}))
 		if err != nil {
 			return nil, err
 		}
@@ -162,7 +162,7 @@ func (q *SGP) Encrypt(x, y data.Vector, msk *SGPSecKey) (*SGPCipher, error) {
 	}
 	aMulG1 := make([]data.VectorG1, q.N)
 	bMulG2 := make([]data.VectorG2, q.N)
-	for i, _ := range a {
+	for i := range a {
 		aMulG1[i] = a[i].MulG1()
 		bMulG2[i] = b[i].MulG2()
 	}


### PR DESCRIPTION
This minor PR potentially improves performance in some parts by removing repeating `append()` calls in loops, which can potentially cause expensive memory reallocations. Instead, if the lengths of slices are known beforehand, they are passed to `make()` calls. Appends are still left in some places where the sizes are unknown or where they aren't called inside loops. Additionally, I fixed (admittedly very nitpicky) things that `golint` considers as issues.