### PR TITLE
Scheme parameters made public

### DIFF
--- a/abe/fame.go
+++ b/abe/fame.go
@@ -52,14 +52,14 @@ func NewFAME() *FAME {
 
 // FAMESecKey represents a master secret key of a FAME scheme.
 type FAMESecKey struct {
-	partInt [4]*big.Int
-	partG1  [3]*bn256.G1
+	PartInt [4]*big.Int
+	PartG1  [3]*bn256.G1
 }
 
 // FAMEPubKey represents a public key of a FAME scheme.
 type FAMEPubKey struct {
-	partG2 [2]*bn256.G2
-	partGT [2]*bn256.GT
+	PartG2 [2]*bn256.G2
+	PartGT [2]*bn256.GT
 }
 
 // GenerateMasterKeys generates a new set of public keys, needed
@@ -83,16 +83,16 @@ func (a *FAME) GenerateMasterKeys() (*FAMEPubKey, *FAMESecKey, error) {
 	partGT := [2]*bn256.GT{new(bn256.GT).ScalarBaseMult(tmp1),
 		new(bn256.GT).ScalarBaseMult(tmp2)}
 
-	return &FAMEPubKey{partG2: partG2, partGT: partGT},
-		&FAMESecKey{partInt: partInt, partG1: partG1}, nil
+	return &FAMEPubKey{PartG2: partG2, PartGT: partGT},
+		&FAMESecKey{PartInt: partInt, PartG1: partG1}, nil
 }
 
 // FAMECipher represents a ciphertext of a FAME scheme.
 type FAMECipher struct {
-	ct0     [3]*bn256.G2
-	ct      [][3]*bn256.G1
-	ctPrime *bn256.GT
-	msp     *MSP
+	Ct0     [3]*bn256.G2
+	Ct      [][3]*bn256.G1
+	CtPrime *bn256.GT
+	Msp     *MSP
 }
 
 // Encrypt takes as an input a message msg represented as an element of an elliptic
@@ -125,8 +125,8 @@ func (a *FAME) Encrypt(msg string, msp *MSP, pk *FAMEPubKey) (*FAMECipher, error
 	if err != nil {
 		return nil, err
 	}
-	ct0 := [3]*bn256.G2{new(bn256.G2).ScalarMult(pk.partG2[0], s[0]),
-		new(bn256.G2).ScalarMult(pk.partG2[1], s[1]),
+	ct0 := [3]*bn256.G2{new(bn256.G2).ScalarMult(pk.PartG2[0], s[0]),
+		new(bn256.G2).ScalarMult(pk.PartG2[1], s[1]),
 		new(bn256.G2).ScalarBaseMult(new(big.Int).Add(s[0], s[1]))}
 
 	ct := make([][3]*bn256.G1, len(msp.Mat))
@@ -172,20 +172,20 @@ func (a *FAME) Encrypt(msg string, msp *MSP, pk *FAMEPubKey) (*FAMECipher, error
 		}
 	}
 
-	ctPrime := new(bn256.GT).ScalarMult(pk.partGT[0], s[0])
-	ctPrime.Add(ctPrime, new(bn256.GT).ScalarMult(pk.partGT[1], s[1]))
+	ctPrime := new(bn256.GT).ScalarMult(pk.PartGT[0], s[0])
+	ctPrime.Add(ctPrime, new(bn256.GT).ScalarMult(pk.PartGT[1], s[1]))
 	ctPrime.Add(ctPrime, msgInGt)
 
-	return &FAMECipher{ct0: ct0, ct: ct, ctPrime: ctPrime, msp: msp}, nil
+	return &FAMECipher{Ct0: ct0, Ct: ct, CtPrime: ctPrime, Msp: msp}, nil
 }
 
 // FAMEAttribKeys represents keys corresponding to attributes possessed by
 // an entity and used for decrypting in a FAME scheme.
 type FAMEAttribKeys struct {
-	k0        [3]*bn256.G2
-	k         [][3]*bn256.G1
-	kPrime    [3]*bn256.G1
-	attribToI map[int]int
+	K0        [3]*bn256.G2
+	K         [][3]*bn256.G1
+	KPrime    [3]*bn256.G1
+	AttribToI map[int]int
 }
 
 // GenerateAttribKeys given a set of attributes gamma and the master secret key
@@ -202,9 +202,9 @@ func (a *FAME) GenerateAttribKeys(gamma []int, sk *FAMESecKey) (*FAMEAttribKeys,
 		return nil, err
 	}
 
-	pow0 := new(big.Int).Mul(sk.partInt[2], r[0])
+	pow0 := new(big.Int).Mul(sk.PartInt[2], r[0])
 	pow0.Mod(pow0, a.P)
-	pow1 := new(big.Int).Mul(sk.partInt[3], r[1])
+	pow1 := new(big.Int).Mul(sk.PartInt[3], r[1])
 	pow1.Mod(pow1, a.P)
 	pow2 := new(big.Int).Add(r[0], r[1])
 	pow2.Mod(pow2, a.P)
@@ -213,8 +213,8 @@ func (a *FAME) GenerateAttribKeys(gamma []int, sk *FAMESecKey) (*FAMEAttribKeys,
 		new(bn256.G2).ScalarBaseMult(pow1),
 		new(bn256.G2).ScalarBaseMult(pow2)}
 
-	a0Inv := new(big.Int).ModInverse(sk.partInt[0], a.P)
-	a1Inv := new(big.Int).ModInverse(sk.partInt[1], a.P)
+	a0Inv := new(big.Int).ModInverse(sk.PartInt[0], a.P)
+	a1Inv := new(big.Int).ModInverse(sk.PartInt[1], a.P)
 	aInv := [2]*big.Int{a0Inv, a1Inv}
 
 	k := make([][3]*bn256.G1, len(gamma))
@@ -279,14 +279,14 @@ func (a *FAME) GenerateAttribKeys(gamma []int, sk *FAMESecKey) (*FAMEAttribKeys,
 		kPrime[t].Add(kPrime[t], hs2)
 		kPrime[t].Add(kPrime[t], gSigmaPrime)
 		kPrime[t].ScalarMult(kPrime[t], aInv[t])
-		kPrime[t].Add(kPrime[t], sk.partG1[t])
+		kPrime[t].Add(kPrime[t], sk.PartG1[t])
 
 	}
 	kPrime[2].ScalarBaseMult(sigmaPrime)
 	kPrime[2].Neg(kPrime[2])
-	kPrime[2].Add(kPrime[2], sk.partG1[2])
+	kPrime[2].Add(kPrime[2], sk.PartG1[2])
 
-	return &FAMEAttribKeys{k0: k0, k: k, kPrime: kPrime, attribToI: attribToI}, nil
+	return &FAMEAttribKeys{K0: k0, K: k, KPrime: kPrime, AttribToI: attribToI}, nil
 }
 
 // Decrypt takes as an input a cipher and an FAMEAttribKeys and tries to decrypt
@@ -296,13 +296,13 @@ func (a *FAME) GenerateAttribKeys(gamma []int, sk *FAMESecKey) (*FAMEAttribKeys,
 func (a *FAME) Decrypt(cipher *FAMECipher, key *FAMEAttribKeys, pk *FAMEPubKey) (string, error) {
 	// find out which attributes are owned
 	attribMap := make(map[int]bool)
-	for k := range key.attribToI {
+	for k := range key.AttribToI {
 		attribMap[k] = true
 	}
 
 	countAttrib := 0
-	for i := 0; i < len(cipher.msp.Mat); i++ {
-		if attribMap[cipher.msp.RowToAttrib[i]] {
+	for i := 0; i < len(cipher.Msp.Mat); i++ {
+		if attribMap[cipher.Msp.RowToAttrib[i]] {
 			countAttrib++
 		}
 	}
@@ -312,11 +312,11 @@ func (a *FAME) Decrypt(cipher *FAMECipher, key *FAMEAttribKeys, pk *FAMEPubKey) 
 	ctForKey := make([][3]*bn256.G1, countAttrib)
 	rowToAttrib := make([]int, countAttrib)
 	countAttrib = 0
-	for i := 0; i < len(cipher.msp.Mat); i++ {
-		if attribMap[cipher.msp.RowToAttrib[i]] {
-			preMatForKey[countAttrib] = cipher.msp.Mat[i]
-			ctForKey[countAttrib] = cipher.ct[i]
-			rowToAttrib[countAttrib] = cipher.msp.RowToAttrib[i]
+	for i := 0; i < len(cipher.Msp.Mat); i++ {
+		if attribMap[cipher.Msp.RowToAttrib[i]] {
+			preMatForKey[countAttrib] = cipher.Msp.Mat[i]
+			ctForKey[countAttrib] = cipher.Ct[i]
+			rowToAttrib[countAttrib] = cipher.Msp.RowToAttrib[i]
 			countAttrib++
 		}
 	}
@@ -334,7 +334,7 @@ func (a *FAME) Decrypt(cipher *FAMECipher, key *FAMEAttribKeys, pk *FAMEPubKey) 
 		return "", fmt.Errorf("provided key is not sufficient for decryption")
 	}
 
-	msgInGt := new(bn256.GT).Set(cipher.ctPrime)
+	msgInGt := new(bn256.GT).Set(cipher.CtPrime)
 
 	ctProd := new([3]*bn256.G1)
 	keyProd := new([3]*bn256.G1)
@@ -343,11 +343,11 @@ func (a *FAME) Decrypt(cipher *FAMECipher, key *FAMEAttribKeys, pk *FAMEPubKey) 
 		keyProd[j] = new(bn256.G1).ScalarBaseMult(big.NewInt(0))
 		for i, e := range rowToAttrib {
 			ctProd[j].Add(ctProd[j], new(bn256.G1).ScalarMult(ctForKey[i][j], alpha[i]))
-			keyProd[j].Add(keyProd[j], new(bn256.G1).ScalarMult(key.k[key.attribToI[e]][j], alpha[i]))
+			keyProd[j].Add(keyProd[j], new(bn256.G1).ScalarMult(key.K[key.AttribToI[e]][j], alpha[i]))
 		}
-		keyProd[j].Add(keyProd[j], key.kPrime[j])
-		ctPairing := bn256.Pair(ctProd[j], key.k0[j])
-		keyPairing := bn256.Pair(keyProd[j], cipher.ct0[j])
+		keyProd[j].Add(keyProd[j], key.KPrime[j])
+		ctPairing := bn256.Pair(ctProd[j], key.K0[j])
+		keyPairing := bn256.Pair(keyProd[j], cipher.Ct0[j])
 		keyPairing.Neg(keyPairing)
 		msgInGt.Add(msgInGt, ctPairing)
 		msgInGt.Add(msgInGt, keyPairing)

--- a/innerprod/fullysec/lwe.go
+++ b/innerprod/fullysec/lwe.go
@@ -29,8 +29,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// LweParams represents parameters for the fully secure LWE scheme.
-type LweParams struct {
+// LWEParams represents parameters for the fully secure LWE scheme.
+type LWEParams struct {
 	L      int      // Length of data vectors for inner product
 
 	N      int      // Main security parameters of the scheme
@@ -65,7 +65,7 @@ type LweParams struct {
 // "Fully secure functional encryption for inner products,
 // from standard assumptions".
 type LWE struct {
-	Params *LweParams
+	Params *LWEParams
 }
 
 // NewLWE configures a new instance of the scheme.
@@ -174,7 +174,7 @@ func NewLWE(l, n int, boundX, boundY *big.Int) (*LWE, error) {
 			"cannot generate parameters, generating a random matrix failed")
 	}
 	return &LWE{
-		Params: &LweParams{
+		Params: &LWEParams{
 			L:      l,
 			N:      n,
 			M:      m,

--- a/innerprod/fullysec/lwe.go
+++ b/innerprod/fullysec/lwe.go
@@ -29,34 +29,34 @@ import (
 	"github.com/pkg/errors"
 )
 
-// lweParams represents parameters for the fully secure LWE scheme.
-type lweParams struct {
-	l int // Length of data vectors for inner product
+// LweParams represents parameters for the fully secure LWE scheme.
+type LweParams struct {
+	L      int      // Length of data vectors for inner product
 
-	n int // Main security parameters of the scheme
-	m int // Number of samples
+	N      int      // Main security parameters of the scheme
+	M      int      // Number of samples
 
-	boundX *big.Int // Message space size
-	boundY *big.Int // Inner product vector space size
+	BoundX *big.Int // Message space size
+	BoundY *big.Int // Inner product vector space size
 
-	// Modulus for the resulting inner product.
-	// K depends on the parameters l, P and V and is computed by the scheme.
-	K *big.Int
+			// Modulus for the resulting inner product.
+			// K depends on the parameters L, P and V and is computed by the scheme.
+	K      *big.Int
 
-	// Modulus for ciphertext and keys.
-	// Must be significantly larger than K.
-	// TODO check appropriateness of this parameter in constructor!
-	q *big.Int
+			// Modulus for ciphertext and keys.
+			// Must be significantly larger than K.
+			// TODO check appropriateness of this parameter in constructor!
+	Q      *big.Int
 
-	// standard deviation for the noise terms in the encryption process
-	sigmaQ *big.Float
-	// standard deviation for first half of the matrix for sampling private key
-	sigma1 *big.Float
-	// standard deviation for second half of the matrix for sampling private key
-	sigma2 *big.Float
+			// standard deviation for the noise terms in the encryption process
+	SigmaQ *big.Float
+			// standard deviation for first half of the matrix for sampling private key
+	Sigma1 *big.Float
+			// standard deviation for second half of the matrix for sampling private key
+	Sigma2 *big.Float
 
-	// Matrix A of dimensions m*n is a public parameter of the scheme
-	A data.Matrix
+			// Matrix A of dimensions M*N is a public parameter of the scheme
+	A      data.Matrix
 }
 
 // LWE represents a scheme instantiated from the LWE problem.
@@ -65,7 +65,7 @@ type lweParams struct {
 // "Fully secure functional encryption for inner products,
 // from standard assumptions".
 type LWE struct {
-	params *lweParams
+	Params *LweParams
 }
 
 // NewLWE configures a new instance of the scheme.
@@ -174,17 +174,17 @@ func NewLWE(l, n int, boundX, boundY *big.Int) (*LWE, error) {
 			"cannot generate parameters, generating a random matrix failed")
 	}
 	return &LWE{
-		params: &lweParams{
-			l:      l,
-			n:      n,
-			m:      m,
-			boundX: boundX,
-			boundY: boundY,
-			q:      q,
+		Params: &LweParams{
+			L:      l,
+			N:      n,
+			M:      m,
+			BoundX: boundX,
+			BoundY: boundY,
+			Q:      q,
 			K:      K,
-			sigmaQ: sigmaQ,
-			sigma1: sigma1,
-			sigma2: sigma2,
+			SigmaQ: sigmaQ,
+			Sigma1: sigma1,
+			Sigma2: sigma2,
 			A:      randMat,
 		},
 	}, nil
@@ -197,19 +197,19 @@ func NewLWE(l, n int, boundX, boundY *big.Int) (*LWE, error) {
 func (s *LWE) GenerateSecretKey() (data.Matrix, error) {
 	var val *big.Int
 
-	sampler1, err := sample.NewNormalDouble(s.params.sigma1, uint(s.params.n), big.NewFloat(1))
+	sampler1, err := sample.NewNormalDouble(s.Params.Sigma1, uint(s.Params.N), big.NewFloat(1))
 	if err != nil {
 		return nil, errors.Wrap(err, "error generating secret key")
 	}
-	sampler2, err := sample.NewNormalDouble(s.params.sigma2, uint(s.params.n), big.NewFloat(1))
+	sampler2, err := sample.NewNormalDouble(s.Params.Sigma2, uint(s.Params.N), big.NewFloat(1))
 	if err != nil {
 		return nil, errors.Wrap(err, "error generating secret key")
 	}
 
-	Z := make(data.Matrix, s.params.l)
+	Z := make(data.Matrix, s.Params.L)
 	halfRows := Z.Rows() / 2
 	for i := 0; i < Z.Rows(); i++ {
-		Z[i] = make(data.Vector, s.params.m)
+		Z[i] = make(data.Vector, s.Params.M)
 		for j := 0; j < Z.Cols(); j++ {
 			if j < halfRows { // first half
 				val, _ = sampler1.Sample()
@@ -232,12 +232,12 @@ func (s *LWE) GenerateSecretKey() (data.Matrix, error) {
 // Public key is a matrix of l*m elements.
 // In case of a malformed secret key the function returns an error.
 func (s *LWE) GeneratePublicKey(Z data.Matrix) (data.Matrix, error) {
-	if !Z.CheckDims(s.params.l, s.params.m) {
+	if !Z.CheckDims(s.Params.L, s.Params.M) {
 		return nil, gofe.MalformedSecKey
 	}
 	// public key is obtained by multiplying secret key Z by a random matrix A.
-	U, _ := Z.Mul(s.params.A)
-	U = U.Mod(s.params.q)
+	U, _ := Z.Mul(s.Params.A)
+	U = U.Mod(s.Params.Q)
 
 	return U, nil
 }
@@ -247,10 +247,10 @@ func (s *LWE) GeneratePublicKey(Z data.Matrix) (data.Matrix, error) {
 // In case of malformed secret key or input vector that violates the
 // configured bound, it returns an error.
 func (s *LWE) DeriveKey(y data.Vector, Z data.Matrix) (data.Vector, error) {
-	if err := y.CheckBound(s.params.boundY); err != nil {
+	if err := y.CheckBound(s.Params.BoundY); err != nil {
 		return nil, err
 	}
-	if !Z.CheckDims(s.params.l, s.params.m) {
+	if !Z.CheckDims(s.Params.L, s.Params.M) {
 		return nil, gofe.MalformedSecKey
 	}
 	// Secret key is a linear combination of input vector x and master secret key Z.
@@ -258,7 +258,7 @@ func (s *LWE) DeriveKey(y data.Vector, Z data.Matrix) (data.Vector, error) {
 	if err != nil {
 		return nil, gofe.MalformedInput
 	}
-	zY = zY.Mod(s.params.q)
+	zY = zY.Mod(s.Params.Q)
 
 	return zY, nil
 }
@@ -268,46 +268,46 @@ func (s *LWE) DeriveKey(y data.Vector, Z data.Matrix) (data.Vector, error) {
 // public key or input vector that violates the configured bound,
 // it returns an error.
 func (s *LWE) Encrypt(x data.Vector, U data.Matrix) (data.Vector, error) {
-	if err := x.CheckBound(s.params.boundX); err != nil {
+	if err := x.CheckBound(s.Params.BoundX); err != nil {
 		return nil, err
 	}
-	if !U.CheckDims(s.params.l, s.params.n) {
+	if !U.CheckDims(s.Params.L, s.Params.N) {
 		return nil, gofe.MalformedPubKey
 	}
-	if len(x) != s.params.l {
+	if len(x) != s.Params.L {
 		return nil, gofe.MalformedInput
 	}
 
 	// Create a random vector
-	r, err := data.NewRandomVector(s.params.n, sample.NewUniform(s.params.q))
+	r, err := data.NewRandomVector(s.Params.N, sample.NewUniform(s.Params.Q))
 	if err != nil {
 		return nil, errors.Wrap(err, "error in encrypt")
 	}
 
 	// calculate the standard distribution and sample vectors e0, e1
-	sampler, err := sample.NewNormalDouble(s.params.sigmaQ, uint(s.params.n), big.NewFloat(1))
+	sampler, err := sample.NewNormalDouble(s.Params.SigmaQ, uint(s.Params.N), big.NewFloat(1))
 	if err != nil {
 		return nil, errors.Wrap(err, "error in encrypt")
 	}
-	e0, err0 := data.NewRandomVector(s.params.m, sampler)
-	e1, err1 := data.NewRandomVector(s.params.l, sampler)
+	e0, err0 := data.NewRandomVector(s.Params.M, sampler)
+	e1, err1 := data.NewRandomVector(s.Params.L, sampler)
 	if err0 != nil || err1 != nil {
 		return nil, errors.Wrap(err0, "error in encrypt")
 	}
 
 	// calculate first part of the cipher
-	c0, _ := s.params.A.MulVec(r)
+	c0, _ := s.Params.A.MulVec(r)
 	c0 = c0.Add(e0)
-	c0 = c0.Mod(s.params.q)
+	c0 = c0.Mod(s.Params.Q)
 
 	// calculate second part of the cipher
-	qDivK := new(big.Int).Div(s.params.q, s.params.K)
+	qDivK := new(big.Int).Div(s.Params.Q, s.Params.K)
 	t := x.MulScalar(qDivK) // center
 
 	c1, _ := U.MulVec(r)
 	c1 = c1.Add(e1)
 	c1 = c1.Add(t)
-	c1 = c1.Mod(s.params.q)
+	c1 = c1.Mod(s.Params.Q)
 
 	return append(c0, c1...), nil
 }
@@ -317,33 +317,33 @@ func (s *LWE) Encrypt(x data.Vector, U data.Matrix) (data.Vector, error) {
 // If decryption failed (for instance with input data that violates the
 // configured bound or malformed ciphertext or keys), error is returned.
 func (s *LWE) Decrypt(cipher, zY, y data.Vector) (*big.Int, error) {
-	if err := y.CheckBound(s.params.boundY); err != nil {
+	if err := y.CheckBound(s.Params.BoundY); err != nil {
 		return nil, err
 	}
-	if len(zY) != s.params.m {
+	if len(zY) != s.Params.M {
 		return nil, gofe.MalformedDecKey
 	}
-	if len(y) != s.params.l {
+	if len(y) != s.Params.L {
 		return nil, gofe.MalformedInput
 	}
 
-	if len(cipher) != s.params.m+s.params.l {
+	if len(cipher) != s.Params.M +s.Params.L {
 		return nil, gofe.MalformedCipher
 	}
-	c0 := cipher[:s.params.m]
-	c1 := cipher[s.params.m:]
+	c0 := cipher[:s.Params.M]
+	c1 := cipher[s.Params.M:]
 	yDotC1, _ := y.Dot(c1)
 	zYDotC0, _ := zY.Dot(c0)
 
 	mu1 := new(big.Int).Sub(yDotC1, zYDotC0)
-	mu1.Mod(mu1, s.params.q)
-	if mu1.Cmp(new(big.Int).Quo(s.params.q, big.NewInt(2))) == 1 {
-		mu1.Sub(mu1, s.params.q)
+	mu1.Mod(mu1, s.Params.Q)
+	if mu1.Cmp(new(big.Int).Quo(s.Params.Q, big.NewInt(2))) == 1 {
+		mu1.Sub(mu1, s.Params.Q)
 	}
 	// TODO Improve!
-	kTimes2 := new(big.Int).Lsh(s.params.K, 1)
-	qDivK := new(big.Int).Div(s.params.q, s.params.K)
-	qDivKTimes2 := new(big.Int).Div(s.params.q, kTimes2)
+	kTimes2 := new(big.Int).Lsh(s.Params.K, 1)
+	qDivK := new(big.Int).Div(s.Params.Q, s.Params.K)
+	qDivKTimes2 := new(big.Int).Div(s.Params.Q, kTimes2)
 
 	mu := new(big.Int).Add(mu1, qDivKTimes2)
 	mu.Div(mu, qDivK)

--- a/innerprod/fullysec/paillier.go
+++ b/innerprod/fullysec/paillier.go
@@ -29,16 +29,16 @@ import (
 	"github.com/fentec-project/gofe/sample"
 )
 
-// paillerParams represents parameters for the fully secure Paillier scheme.
-type paillerParams struct {
-	l       int        // Length of data vectors for inner product
-	n       *big.Int   // a big integer, a product of two safe primes
-	nSquare *big.Int   // n^2 a modulus for computations
-	boundX  *big.Int   // a bound on the entries of the input vector
-	boundY  *big.Int   // a bound on the entries of the inner product vector
-	sigma   *big.Float // the standard deviation for the sampling a secret key
-	lambda  int        // security parameter
-	g       *big.Int   // generator of the 2n-th residues subgroup of Z_n^2*
+// PaillerParams represents parameters for the fully secure Paillier scheme.
+type PaillerParams struct {
+	L       int        // Length of data vectors for inner product
+	N       *big.Int   // a big integer, a product of two safe primes
+	NSquare *big.Int   // N^2 a modulus for computations
+	BoundX  *big.Int   // a bound on the entries of the input vector
+	BoundY  *big.Int   // a bound on the entries of the inner product vector
+	Sigma   *big.Float // the standard deviation for the sampling a secret key
+	Lambda  int        // security parameter
+	G       *big.Int   // generator of the 2n-th residues subgroup of Z_N^2*
 }
 
 // Paillier represents a scheme based on the Paillier variant by
@@ -46,7 +46,7 @@ type paillerParams struct {
 // "Fully secure functional encryption for inner products,
 // from standard assumptions".
 type Paillier struct {
-	Params *paillerParams
+	Params *PaillerParams
 }
 
 // NewPaillier configures a new instance of the scheme.
@@ -119,15 +119,15 @@ func NewPaillier(l, lambda, bitLen int, boundX, boundY *big.Int) (*Paillier, err
 	sigma.SetInt(sigmaI)
 
 	return &Paillier{
-		Params: &paillerParams{
-			l:       l,
-			n:       n,
-			nSquare: nSquare,
-			boundX:  boundX,
-			boundY:  boundY,
-			sigma:   sigma,
-			lambda:  lambda,
-			g:       g,
+		Params: &PaillerParams{
+			L:       l,
+			N:       n,
+			NSquare: nSquare,
+			BoundX:  boundX,
+			BoundY:  boundY,
+			Sigma:   sigma,
+			Lambda:  lambda,
+			G:       g,
 		},
 	}, nil
 }
@@ -135,7 +135,7 @@ func NewPaillier(l, lambda, bitLen int, boundX, boundY *big.Int) (*Paillier, err
 // NewPaillierFromParams takes configuration parameters of an existing
 // Paillier scheme instance, and reconstructs the scheme with same configuration
 // parameters. It returns a new Paillier instance.
-func NewPaillierFromParams(params *paillerParams) *Paillier {
+func NewPaillierFromParams(params *PaillerParams) *Paillier {
 	return &Paillier{
 		Params: params,
 	}
@@ -146,20 +146,20 @@ func NewPaillierFromParams(params *paillerParams) *Paillier {
 // could not be generated.
 func (s *Paillier) GenerateMasterKeys() (data.Vector, data.Vector, error) {
 	// sampler for sampling a secret key
-	sampler, err := sample.NewNormalDouble(s.Params.sigma, uint(s.Params.lambda),
+	sampler, err := sample.NewNormalDouble(s.Params.Sigma, uint(s.Params.Lambda),
 		big.NewFloat(1))
 	if err != nil {
 		return nil, nil, err
 	}
 	// generate a secret key
-	secKey, err := data.NewRandomVector(s.Params.l, sampler)
+	secKey, err := data.NewRandomVector(s.Params.L, sampler)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// derive the public key from the generated secret key
 	pubKey := secKey.Apply(func(x *big.Int) *big.Int {
-		return internal.ModExp(s.Params.g, x, s.Params.nSquare)
+		return internal.ModExp(s.Params.G, x, s.Params.NSquare)
 	})
 	return secKey, pubKey, nil
 }
@@ -169,7 +169,7 @@ func (s *Paillier) GenerateMasterKeys() (data.Vector, data.Vector, error) {
 // In case of malformed secret key or input vector that violates the configured
 // bound, it returns an error.
 func (s *Paillier) DeriveKey(masterSecKey data.Vector, y data.Vector) (*big.Int, error) {
-	if err := y.CheckBound(s.Params.boundY); err != nil {
+	if err := y.CheckBound(s.Params.BoundY); err != nil {
 		return nil, err
 	}
 
@@ -179,29 +179,29 @@ func (s *Paillier) DeriveKey(masterSecKey data.Vector, y data.Vector) (*big.Int,
 // Encrypt encrypts input vector x with the provided master public key.
 // It returns a ciphertext vector. If encryption failed, error is returned.
 func (s *Paillier) Encrypt(x, masterPubKey data.Vector) (data.Vector, error) {
-	if err := x.CheckBound(s.Params.boundX); err != nil {
+	if err := x.CheckBound(s.Params.BoundX); err != nil {
 		return nil, err
 	}
 
 	// generate a randomness for the encryption
-	nOver4 := new(big.Int).Quo(s.Params.n, big.NewInt(4))
+	nOver4 := new(big.Int).Quo(s.Params.N, big.NewInt(4))
 	r, err := rand.Int(rand.Reader, nOver4)
 	if err != nil {
 		return nil, err
 	}
 
 	// encrypt x under randomness r
-	cipher := make(data.Vector, s.Params.l+1)
+	cipher := make(data.Vector, s.Params.L +1)
 	// c_0 = g^r in Z_n^2
-	c0 := new(big.Int).Exp(s.Params.g, r, s.Params.nSquare)
+	c0 := new(big.Int).Exp(s.Params.G, r, s.Params.NSquare)
 	cipher[0] = c0
-	for i := 0; i < s.Params.l; i++ {
+	for i := 0; i < s.Params.L; i++ {
 		// c_i = (1 + x_i * n) * pubKey_i^r in Z_n^2
-		t1 := new(big.Int).Mul(x[i], s.Params.n)
+		t1 := new(big.Int).Mul(x[i], s.Params.N)
 		t1.Add(t1, big.NewInt(1))
-		t2 := new(big.Int).Exp(masterPubKey[i], r, s.Params.nSquare)
+		t2 := new(big.Int).Exp(masterPubKey[i], r, s.Params.NSquare)
 		ct := new(big.Int).Mul(t1, t2)
-		ct.Mod(ct, s.Params.nSquare)
+		ct.Mod(ct, s.Params.NSquare)
 		cipher[i+1] = ct
 	}
 
@@ -211,28 +211,28 @@ func (s *Paillier) Encrypt(x, masterPubKey data.Vector) (data.Vector, error) {
 // Decrypt accepts the encrypted vector, functional encryption key, and
 // a vector y. It returns the inner product of x and y.
 func (s *Paillier) Decrypt(cipher data.Vector, key *big.Int, y data.Vector) (*big.Int, error) {
-	if err := y.CheckBound(s.Params.boundY); err != nil {
+	if err := y.CheckBound(s.Params.BoundY); err != nil {
 		return nil, err
 	}
 	// tmp value cX is calculated as (prod_{i=1 to l} c_i^y_i) * c_0^(-key) in Z_n^2
 	keyNeg := new(big.Int).Neg(key)
-	cX := internal.ModExp(cipher[0], keyNeg, s.Params.nSquare)
+	cX := internal.ModExp(cipher[0], keyNeg, s.Params.NSquare)
 
 	for i, ct := range cipher[1:] {
-		t1 := internal.ModExp(ct, y[i], s.Params.nSquare)
+		t1 := internal.ModExp(ct, y[i], s.Params.NSquare)
 		cX.Mul(cX, t1)
-		cX.Mod(cX, s.Params.nSquare)
+		cX.Mod(cX, s.Params.NSquare)
 	}
 
 	// decryption is calculated as (cX-1 mod n^2)/n
 	cX.Sub(cX, big.NewInt(1))
-	cX.Mod(cX, s.Params.nSquare)
-	ret := new(big.Int).Quo(cX, s.Params.n)
+	cX.Mod(cX, s.Params.NSquare)
+	ret := new(big.Int).Quo(cX, s.Params.N)
 	// if the return value is negative this is seen as the above ret being
 	// greater than n/2; in this case ret = ret - n
-	nHalf := new(big.Int).Quo(s.Params.n, big.NewInt(2))
+	nHalf := new(big.Int).Quo(s.Params.N, big.NewInt(2))
 	if ret.Cmp(nHalf) == 1 {
-		ret.Sub(ret, s.Params.n)
+		ret.Sub(ret, s.Params.N)
 	}
 
 	return ret, nil

--- a/innerprod/fullysec/paillier.go
+++ b/innerprod/fullysec/paillier.go
@@ -30,7 +30,7 @@ import (
 )
 
 // PaillerParams represents parameters for the fully secure Paillier scheme.
-type PaillerParams struct {
+type PaillierParams struct {
 	L       int        // Length of data vectors for inner product
 	N       *big.Int   // a big integer, a product of two safe primes
 	NSquare *big.Int   // N^2 a modulus for computations
@@ -46,7 +46,7 @@ type PaillerParams struct {
 // "Fully secure functional encryption for inner products,
 // from standard assumptions".
 type Paillier struct {
-	Params *PaillerParams
+	Params *PaillierParams
 }
 
 // NewPaillier configures a new instance of the scheme.
@@ -119,7 +119,7 @@ func NewPaillier(l, lambda, bitLen int, boundX, boundY *big.Int) (*Paillier, err
 	sigma.SetInt(sigmaI)
 
 	return &Paillier{
-		Params: &PaillerParams{
+		Params: &PaillierParams{
 			L:       l,
 			N:       n,
 			NSquare: nSquare,
@@ -135,7 +135,7 @@ func NewPaillier(l, lambda, bitLen int, boundX, boundY *big.Int) (*Paillier, err
 // NewPaillierFromParams takes configuration parameters of an existing
 // Paillier scheme instance, and reconstructs the scheme with same configuration
 // parameters. It returns a new Paillier instance.
-func NewPaillierFromParams(params *PaillerParams) *Paillier {
+func NewPaillierFromParams(params *PaillierParams) *Paillier {
 	return &Paillier{
 		Params: params,
 	}

--- a/innerprod/simple/ddh.go
+++ b/innerprod/simple/ddh.go
@@ -27,8 +27,8 @@ import (
 	emmy "github.com/xlab-si/emmy/crypto/common"
 )
 
-// DdhParams represents configuration parameters for the DDH scheme instance.
-type DdhParams struct {
+// DDHParams represents configuration parameters for the DDH scheme instance.
+type DDHParams struct {
 	// length of input vectors x and y
 	L     int
 	// The value by which coordinates of input vectors x and y are bounded.
@@ -46,7 +46,7 @@ type DdhParams struct {
 // Abdalla, Bourse, De Caro, and Pointchev:
 // "Simple Functional Encryption Schemes for Inner Products".
 type DDH struct {
-	Params *DdhParams
+	Params *DDHParams
 }
 
 // NewDDH configures a new instance of the scheme.
@@ -68,7 +68,7 @@ func NewDDH(l, modulusLength int, bound *big.Int) (*DDH, error) {
 	}
 
 	sip := DDH{
-		Params: &DdhParams{
+		Params: &DDHParams{
 			L:     l,
 			Bound: bound,
 			G:     key.G,
@@ -83,7 +83,7 @@ func NewDDH(l, modulusLength int, bound *big.Int) (*DDH, error) {
 // NewDDHFromParams takes configuration parameters of an existing
 // DDH scheme instance, and reconstructs the scheme with same configuration
 // parameters. It returns a new DDH instance.
-func NewDDHFromParams(params *DdhParams) *DDH {
+func NewDDHFromParams(params *DDHParams) *DDH {
 	return &DDH{
 		Params: params,
 	}

--- a/innerprod/simple/ddh.go
+++ b/innerprod/simple/ddh.go
@@ -27,18 +27,18 @@ import (
 	emmy "github.com/xlab-si/emmy/crypto/common"
 )
 
-// ddhParams represents configuration parameters for the DDH scheme instance.
-type ddhParams struct {
+// DdhParams represents configuration parameters for the DDH scheme instance.
+type DdhParams struct {
 	// length of input vectors x and y
-	l int
+	L     int
 	// The value by which coordinates of input vectors x and y are bounded.
-	bound *big.Int
-	// Generator of a cyclic group Z_p: g^(q) = 1 (mod p).
-	g *big.Int
-	// Modulus - we are operating in a cyclic group Z_p.
-	p *big.Int
-	// Order of the generator g.
-	q *big.Int
+	Bound *big.Int
+	// Generator of a cyclic group Z_P: G^(Q) = 1 (mod P).
+	G     *big.Int
+	// Modulus - we are operating in a cyclic group Z_P.
+	P     *big.Int
+	// Order of the generator G.
+	Q     *big.Int
 }
 
 // DDH represents a scheme instantiated from the DDH assumption,
@@ -46,7 +46,7 @@ type ddhParams struct {
 // Abdalla, Bourse, De Caro, and Pointchev:
 // "Simple Functional Encryption Schemes for Inner Products".
 type DDH struct {
-	Params *ddhParams
+	Params *DdhParams
 }
 
 // NewDDH configures a new instance of the scheme.
@@ -68,12 +68,12 @@ func NewDDH(l, modulusLength int, bound *big.Int) (*DDH, error) {
 	}
 
 	sip := DDH{
-		Params: &ddhParams{
-			l:     l,
-			bound: bound,
-			g:     key.G,
-			p:     key.P,
-			q:     key.Q,
+		Params: &DdhParams{
+			L:     l,
+			Bound: bound,
+			G:     key.G,
+			P:     key.P,
+			Q:     key.Q,
 		},
 	}
 
@@ -83,7 +83,7 @@ func NewDDH(l, modulusLength int, bound *big.Int) (*DDH, error) {
 // NewDDHFromParams takes configuration parameters of an existing
 // DDH scheme instance, and reconstructs the scheme with same configuration
 // parameters. It returns a new DDH instance.
-func NewDDHFromParams(params *ddhParams) *DDH {
+func NewDDHFromParams(params *DdhParams) *DDH {
 	return &DDH{
 		Params: params,
 	}
@@ -93,15 +93,15 @@ func NewDDHFromParams(params *ddhParams) *DDH {
 // public key for the scheme. It returns an error in case master keys
 // could not be generated.
 func (d *DDH) GenerateMasterKeys() (data.Vector, data.Vector, error) {
-	masterSecKey := make(data.Vector, d.Params.l)
-	masterPubKey := make(data.Vector, d.Params.l)
+	masterSecKey := make(data.Vector, d.Params.L)
+	masterPubKey := make(data.Vector, d.Params.L)
 
-	for i := 0; i < d.Params.l; i++ {
-		x, err := emmy.GetRandomIntFromRange(big.NewInt(2), d.Params.q)
+	for i := 0; i < d.Params.L; i++ {
+		x, err := emmy.GetRandomIntFromRange(big.NewInt(2), d.Params.Q)
 		if err != nil {
 			return nil, nil, err
 		}
-		y := internal.ModExp(d.Params.g, x, d.Params.p)
+		y := internal.ModExp(d.Params.G, x, d.Params.P)
 		masterSecKey[i] = x
 		masterPubKey[i] = y
 	}
@@ -113,7 +113,7 @@ func (d *DDH) GenerateMasterKeys() (data.Vector, data.Vector, error) {
 // functional encryption key. In case the key could not be derived, it
 // returns an error.
 func (d *DDH) DeriveKey(masterSecKey, y data.Vector) (*big.Int, error) {
-	if err := y.CheckBound(d.Params.bound); err != nil {
+	if err := y.CheckBound(d.Params.Bound); err != nil {
 		return nil, err
 	}
 
@@ -121,32 +121,32 @@ func (d *DDH) DeriveKey(masterSecKey, y data.Vector) (*big.Int, error) {
 	if err != nil {
 		return nil, err
 	}
-	return new(big.Int).Mod(key, d.Params.q), nil
+	return new(big.Int).Mod(key, d.Params.Q), nil
 }
 
 // Encrypt encrypts input vector x with the provided master public key.
 // It returns a ciphertext vector. If encryption failed, error is returned.
 func (d *DDH) Encrypt(x, masterPubKey data.Vector) (data.Vector, error) {
-	if err := x.CheckBound(d.Params.bound); err != nil {
+	if err := x.CheckBound(d.Params.Bound); err != nil {
 		return nil, err
 	}
 
-	r, err := emmy.GetRandomIntFromRange(big.NewInt(1), d.Params.p)
+	r, err := emmy.GetRandomIntFromRange(big.NewInt(1), d.Params.P)
 	if err != nil {
 		return nil, err
 	}
 
 	ciphertext := make([]*big.Int, len(x)+1)
 	// ct0 = g^r
-	ct0 := new(big.Int).Exp(d.Params.g, r, d.Params.p)
+	ct0 := new(big.Int).Exp(d.Params.G, r, d.Params.P)
 	ciphertext[0] = ct0
 
 	for i := 0; i < len(x); i++ {
 		// ct_i = h_i^r * g^x_i
 		// ct_i = mpk[i]^r * g^x_i
-		t1 := new(big.Int).Exp(masterPubKey[i], r, d.Params.p)
-		t2 := internal.ModExp(d.Params.g, x[i], d.Params.p)
-		ct := new(big.Int).Mod(new(big.Int).Mul(t1, t2), d.Params.p)
+		t1 := new(big.Int).Exp(masterPubKey[i], r, d.Params.P)
+		t2 := internal.ModExp(d.Params.G, x[i], d.Params.P)
+		ct := new(big.Int).Mod(new(big.Int).Mul(t1, t2), d.Params.P)
 		ciphertext[i+1] = ct
 	}
 
@@ -157,29 +157,29 @@ func (d *DDH) Encrypt(x, masterPubKey data.Vector) (data.Vector, error) {
 // a plaintext vector y. It returns the inner product of x and y.
 // If decryption failed, error is returned.
 func (d *DDH) Decrypt(cipher data.Vector, key *big.Int, y data.Vector) (*big.Int, error) {
-	if err := y.CheckBound(d.Params.bound); err != nil {
+	if err := y.CheckBound(d.Params.Bound); err != nil {
 		return nil, err
 	}
 
 	num := big.NewInt(1)
 	for i, ct := range cipher[1:] {
-		t1 := internal.ModExp(ct, y[i], d.Params.p)
-		num = num.Mod(new(big.Int).Mul(num, t1), d.Params.p)
+		t1 := internal.ModExp(ct, y[i], d.Params.P)
+		num = num.Mod(new(big.Int).Mul(num, t1), d.Params.P)
 	}
 
-	denom := internal.ModExp(cipher[0], key, d.Params.p)
-	denomInv := new(big.Int).ModInverse(denom, d.Params.p)
-	r := new(big.Int).Mod(new(big.Int).Mul(num, denomInv), d.Params.p)
+	denom := internal.ModExp(cipher[0], key, d.Params.P)
+	denomInv := new(big.Int).ModInverse(denom, d.Params.P)
+	r := new(big.Int).Mod(new(big.Int).Mul(num, denomInv), d.Params.P)
 
-	bound := new(big.Int).Mul(big.NewInt(int64(d.Params.l)), new(big.Int).Exp(d.Params.bound, big.NewInt(2), big.NewInt(0)))
+	bound := new(big.Int).Mul(big.NewInt(int64(d.Params.L)), new(big.Int).Exp(d.Params.Bound, big.NewInt(2), big.NewInt(0)))
 
-	calc, err := dlog.NewCalc().InZp(d.Params.p, d.Params.q)
+	calc, err := dlog.NewCalc().InZp(d.Params.P, d.Params.Q)
 	if err != nil {
 		return nil, err
 	}
 	calc = calc.WithNeg()
 
-	res, err := calc.WithBound(bound).BabyStepGiantStep(r, d.Params.g)
+	res, err := calc.WithBound(bound).BabyStepGiantStep(r, d.Params.G)
 	return res, err
 
 }

--- a/innerprod/simple/ddh_multi.go
+++ b/innerprod/simple/ddh_multi.go
@@ -31,7 +31,7 @@ import (
 // Function-Hiding Realizations and Constructions without Pairings".
 type DDHMulti struct {
 	// number of encryptors
-	slots int
+	Slots int
 	*DDH
 }
 
@@ -50,7 +50,7 @@ func NewDDHMulti(slots, l, modulusLength int, bound *big.Int) (*DDHMulti, error)
 	}
 
 	return &DDHMulti{
-		slots: slots,
+		Slots: slots,
 		DDH:   ddh,
 	}, nil
 }
@@ -60,16 +60,16 @@ func NewDDHMulti(slots, l, modulusLength int, bound *big.Int) (*DDHMulti, error)
 // the scheme with same configuration parameters.
 //
 // It returns a new DDHMulti instance.
-func NewDDHMultiFromParams(slots int, params *ddhParams) *DDHMulti {
+func NewDDHMultiFromParams(slots int, params *DdhParams) *DDHMulti {
 	return &DDHMulti{
-		slots: slots,
+		Slots: slots,
 		DDH:   &DDH{params},
 	}
 }
 
 // DDHMultiSecKey is a secret key for DDH multi input scheme.
 type DDHMultiSecKey struct {
-	msk    data.Matrix
+	Msk    data.Matrix
 	OtpKey data.Matrix
 }
 
@@ -78,11 +78,11 @@ type DDHMultiSecKey struct {
 //
 // It returns an error in case master keys could not be generated.
 func (dm *DDHMulti) GenerateMasterKeys() (data.Matrix, *DDHMultiSecKey, error) {
-	mskVecs := make([]data.Vector, dm.slots)
-	mpkVecs := make([]data.Vector, dm.slots)
-	otpVecs := make([]data.Vector, dm.slots)
+	mskVecs := make([]data.Vector, dm.Slots)
+	mpkVecs := make([]data.Vector, dm.Slots)
+	otpVecs := make([]data.Vector, dm.Slots)
 
-	for i := 0; i < dm.slots; i++ {
+	for i := 0; i < dm.Slots; i++ {
 		masterSecretKey, masterPublicKey, err := dm.DDH.GenerateMasterKeys()
 
 		if err != nil {
@@ -91,7 +91,7 @@ func (dm *DDHMulti) GenerateMasterKeys() (data.Matrix, *DDHMultiSecKey, error) {
 		mskVecs[i] = masterSecretKey
 		mpkVecs[i] = masterPublicKey
 
-		otpVector, err := data.NewRandomVector(dm.Params.l, sample.NewUniform(dm.Params.bound))
+		otpVector, err := data.NewRandomVector(dm.Params.L, sample.NewUniform(dm.Params.Bound))
 		if err != nil {
 			return nil, nil, fmt.Errorf("error in random vector generation")
 		}
@@ -118,7 +118,7 @@ func (dm *DDHMulti) GenerateMasterKeys() (data.Matrix, *DDHMultiSecKey, error) {
 
 // DDHMultiDerivedKey is functional encryption key for DDH Scheme.
 type DDHMultiDerivedKey struct {
-	keys   data.Vector
+	Keys   data.Vector
 	OTPKey *big.Int
 }
 
@@ -126,7 +126,7 @@ type DDHMultiDerivedKey struct {
 // of input vectors, and returns the functional encryption key.
 // In case the key could not be derived, it returns an error.
 func (dm *DDHMulti) DeriveKey(secKey *DDHMultiSecKey, y data.Matrix) (*DDHMultiDerivedKey, error) {
-	if err := y.CheckBound(dm.Params.bound); err != nil {
+	if err := y.CheckBound(dm.Params.Bound); err != nil {
 		return nil, err
 	}
 
@@ -134,12 +134,12 @@ func (dm *DDHMulti) DeriveKey(secKey *DDHMultiSecKey, y data.Matrix) (*DDHMultiD
 	if err != nil {
 		return nil, err
 	}
-	z.Mod(z, dm.Params.bound)
+	z.Mod(z, dm.Params.Bound)
 
-	derivedKeys := make([]*big.Int, dm.slots)
+	derivedKeys := make([]*big.Int, dm.Slots)
 
-	for i := 0; i < dm.slots; i++ {
-		derivedKey, err := dm.DDH.DeriveKey(secKey.msk[i], y[i])
+	for i := 0; i < dm.Slots; i++ {
+		derivedKey, err := dm.DDH.DeriveKey(secKey.Msk[i], y[i])
 		if err != nil {
 			return nil, err
 		}
@@ -155,13 +155,13 @@ func (dm *DDHMulti) DeriveKey(secKey *DDHMultiSecKey, y data.Matrix) (*DDHMultiD
 // It returns the sum of inner products.
 // If decryption failed, error is returned.
 func (dm *DDHMulti) Decrypt(cipher data.Matrix, key *DDHMultiDerivedKey, y data.Matrix) (*big.Int, error) {
-	if err := y.CheckBound(dm.Params.bound); err != nil {
+	if err := y.CheckBound(dm.Params.Bound); err != nil {
 		return nil, err
 	}
 
 	sum := big.NewInt(0)
-	for i := 0; i < dm.slots; i++ {
-		c, err := dm.DDH.Decrypt(cipher[i], key.keys[i], y[i])
+	for i := 0; i < dm.Slots; i++ {
+		c, err := dm.DDH.Decrypt(cipher[i], key.Keys[i], y[i])
 		if err != nil {
 			return nil, err
 		}
@@ -170,7 +170,7 @@ func (dm *DDHMulti) Decrypt(cipher data.Matrix, key *DDHMultiDerivedKey, y data.
 	}
 
 	res := new(big.Int).Sub(sum, key.OTPKey)
-	res.Mod(res, dm.Params.bound)
+	res.Mod(res, dm.Params.Bound)
 	return res, nil
 }
 
@@ -181,7 +181,7 @@ type DDHMultiEnc struct {
 
 // NewDDHMultiEnc takes configuration parameters of an underlying
 // DDH scheme instance, and instantiates a new DDHMultiEnc.
-func NewDDHMultiEnc(params *ddhParams) *DDHMultiEnc {
+func NewDDHMultiEnc(params *DdhParams) *DDHMultiEnc {
 	return &DDHMultiEnc{
 		DDH: &DDH{params},
 	}
@@ -192,12 +192,12 @@ func NewDDHMultiEnc(params *ddhParams) *DDHMultiEnc {
 // is a part of the secret key). It returns the ciphertext vector.
 // If encryption failed, error is returned.
 func (e *DDHMultiEnc) Encrypt(x data.Vector, pubKey, otp data.Vector) (data.Vector, error) {
-	if err := x.CheckBound(e.Params.bound); err != nil {
+	if err := x.CheckBound(e.Params.Bound); err != nil {
 		return nil, err
 	}
 
 	otp = x.Add(otp)
-	otpModulo := otp.Mod(e.Params.bound)
+	otpModulo := otp.Mod(e.Params.Bound)
 
 	return e.DDH.Encrypt(otpModulo, pubKey)
 }

--- a/innerprod/simple/ddh_multi.go
+++ b/innerprod/simple/ddh_multi.go
@@ -60,7 +60,7 @@ func NewDDHMulti(slots, l, modulusLength int, bound *big.Int) (*DDHMulti, error)
 // the scheme with same configuration parameters.
 //
 // It returns a new DDHMulti instance.
-func NewDDHMultiFromParams(slots int, params *DdhParams) *DDHMulti {
+func NewDDHMultiFromParams(slots int, params *DDHParams) *DDHMulti {
 	return &DDHMulti{
 		Slots: slots,
 		DDH:   &DDH{params},
@@ -181,7 +181,7 @@ type DDHMultiEnc struct {
 
 // NewDDHMultiEnc takes configuration parameters of an underlying
 // DDH scheme instance, and instantiates a new DDHMultiEnc.
-func NewDDHMultiEnc(params *DdhParams) *DDHMultiEnc {
+func NewDDHMultiEnc(params *DDHParams) *DDHMultiEnc {
 	return &DDHMultiEnc{
 		DDH: &DDH{params},
 	}

--- a/innerprod/simple/lwe.go
+++ b/innerprod/simple/lwe.go
@@ -31,8 +31,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// LweParams represents parameters for the simple LWE scheme.
-type LweParams struct {
+// LWEParams represents parameters for the simple LWE scheme.
+type LWEParams struct {
 	L      int      // Length of data vectors for inner product
 
 	N      int      // Main security parameters of the scheme
@@ -55,7 +55,7 @@ type LweParams struct {
 // Abdalla, Bourse, De Caro, and Pointchev:
 // "Simple Functional Encryption Schemes for Inner Products".
 type LWE struct {
-	Params *LweParams
+	Params *LWEParams
 }
 
 // NewLWE configures a new instance of the scheme.
@@ -121,7 +121,7 @@ func NewLWE(l int, boundX, boundY *big.Int, n int) (*LWE, error) {
 		return nil, errors.Wrap(err, "cannot generate public parameters")
 	}
 	return &LWE{
-		Params: &LweParams{
+		Params: &LWEParams{
 			L:      l,
 			BoundX: boundX,
 			BoundY: boundY,

--- a/innerprod/simple/lwe.go
+++ b/innerprod/simple/lwe.go
@@ -31,23 +31,23 @@ import (
 	"github.com/pkg/errors"
 )
 
-// lweParams represents parameters for the simple LWE scheme.
-type lweParams struct {
-	l int // Length of data vectors for inner product
+// LweParams represents parameters for the simple LWE scheme.
+type LweParams struct {
+	L      int      // Length of data vectors for inner product
 
-	n int // Main security parameters of the scheme
-	m int // Number of rows (samples) for the LWE problem
+	N      int      // Main security parameters of the scheme
+	M      int      // Number of rows (samples) for the LWE problem
 
-	boundX *big.Int // Bound for input vector coordinates (for x)
-	boundY *big.Int // Bound for inner product vector coordinates (for y)
+	BoundX *big.Int // Bound for input vector coordinates (for x)
+	BoundY *big.Int // Bound for inner product vector coordinates (for y)
 
-	p *big.Int // Modulus for message space
-	q *big.Int // Modulus for ciphertext and keys
+	P      *big.Int // Modulus for message space
+	Q      *big.Int // Modulus for ciphertext and keys
 
-	sigmaQ *big.Float
+	SigmaQ *big.Float
 
-	// Matrix A of dimensions m*n is a public parameter of the scheme
-	A data.Matrix
+			// Matrix A of dimensions M*N is a public parameter of the scheme
+	A      data.Matrix
 }
 
 // LWE represents a scheme instantiated from the LWE assumption,
@@ -55,7 +55,7 @@ type lweParams struct {
 // Abdalla, Bourse, De Caro, and Pointchev:
 // "Simple Functional Encryption Schemes for Inner Products".
 type LWE struct {
-	params *lweParams
+	Params *LweParams
 }
 
 // NewLWE configures a new instance of the scheme.
@@ -121,16 +121,16 @@ func NewLWE(l int, boundX, boundY *big.Int, n int) (*LWE, error) {
 		return nil, errors.Wrap(err, "cannot generate public parameters")
 	}
 	return &LWE{
-		params: &lweParams{
-			l:      l,
-			boundX: boundX,
-			boundY: boundY,
-			n:      n,
-			m:      m,
-			p:      p,
-			q:      q,
+		Params: &LweParams{
+			L:      l,
+			BoundX: boundX,
+			BoundY: boundY,
+			N:      n,
+			M:      m,
+			P:      p,
+			Q:      q,
 			A:      A,
-			sigmaQ: sigmaQ,
+			SigmaQ: sigmaQ,
 		},
 	}, nil
 }
@@ -141,7 +141,7 @@ func NewLWE(l int, boundX, boundY *big.Int, n int) (*LWE, error) {
 //
 // In case secret key could not be generated, it returns an error.
 func (s *LWE) GenerateSecretKey() (data.Matrix, error) {
-	return data.NewRandomMatrix(s.params.n, s.params.l, sample.NewUniform(s.params.q))
+	return data.NewRandomMatrix(s.Params.N, s.Params.L, sample.NewUniform(s.Params.Q))
 }
 
 // GeneratePublicKey accepts a secret key SK, standard deviation sigma.
@@ -150,17 +150,17 @@ func (s *LWE) GenerateSecretKey() (data.Matrix, error) {
 //
 // In case of a malformed secret key the function returns an error.
 func (s *LWE) GeneratePublicKey(SK data.Matrix) (data.Matrix, error) {
-	if !SK.CheckDims(s.params.n, s.params.l) {
+	if !SK.CheckDims(s.Params.N, s.Params.L) {
 		return nil, gofe.MalformedSecKey
 	}
 
 	// Initialize and fill noise matrix E with m*l samples
-	sampler, err := sample.NewNormalDouble(s.params.sigmaQ, uint(s.params.n), big.NewFloat(1))
+	sampler, err := sample.NewNormalDouble(s.Params.SigmaQ, uint(s.Params.N), big.NewFloat(1))
 	if err != nil {
 		return nil, errors.Wrap(err, "error generating public key")
 	}
 
-	E, err := data.NewRandomMatrix(s.params.m, s.params.l, sampler)
+	E, err := data.NewRandomMatrix(s.Params.M, s.Params.L, sampler)
 	if err != nil {
 		return nil, errors.Wrap(err, "error generating public key")
 	}
@@ -168,10 +168,10 @@ func (s *LWE) GeneratePublicKey(SK data.Matrix) (data.Matrix, error) {
 	// Calculate public key as PK = (A * SK + E) % q
 	// we ignore error checks because they errors could only arise if SK
 	// was not of the proper form, but we validated it at the beginning
-	PK, _ := s.params.A.Mul(SK)
-	PK = PK.Mod(s.params.q)
+	PK, _ := s.Params.A.Mul(SK)
+	PK = PK.Mod(s.Params.Q)
 	PK, _ = PK.Add(E)
-	PK = PK.Mod(s.params.q)
+	PK = PK.Mod(s.Params.Q)
 
 	return PK, nil
 }
@@ -182,10 +182,10 @@ func (s *LWE) GeneratePublicKey(SK data.Matrix) (data.Matrix, error) {
 // In case of malformed secret key or input vector that violates the configured
 // bound, it returns an error.
 func (s *LWE) DeriveKey(y data.Vector, SK data.Matrix) (data.Vector, error) {
-	if err := y.CheckBound(s.params.boundY); err != nil {
+	if err := y.CheckBound(s.Params.BoundY); err != nil {
 		return nil, err
 	}
-	if !SK.CheckDims(s.params.n, s.params.l) {
+	if !SK.CheckDims(s.Params.N, s.Params.L) {
 		return nil, gofe.MalformedSecKey
 	}
 	// Secret key is a linear combination of input vector y
@@ -194,7 +194,7 @@ func (s *LWE) DeriveKey(y data.Vector, SK data.Matrix) (data.Vector, error) {
 	if err != nil {
 		return nil, gofe.MalformedInput
 	}
-	skY = skY.Mod(s.params.q)
+	skY = skY.Mod(s.Params.Q)
 
 	return skY, nil
 }
@@ -204,18 +204,18 @@ func (s *LWE) DeriveKey(y data.Vector, SK data.Matrix) (data.Vector, error) {
 // public key or input vector that violates the configured bound,
 // it returns an error.
 func (s *LWE) Encrypt(x data.Vector, PK data.Matrix) (data.Vector, error) {
-	if err := x.CheckBound(s.params.boundX); err != nil {
+	if err := x.CheckBound(s.Params.BoundX); err != nil {
 		return nil, err
 	}
-	if !PK.CheckDims(s.params.m, s.params.l) {
+	if !PK.CheckDims(s.Params.M, s.Params.L) {
 		return nil, gofe.MalformedPubKey
 	}
-	if len(x) != s.params.l {
+	if len(x) != s.Params.L {
 		return nil, gofe.MalformedInput
 	}
 
 	// Create a random vector comprised of m 0s and 1s
-	r, err := data.NewRandomVector(s.params.m, sample.NewBit())
+	r, err := data.NewRandomVector(s.Params.M, sample.NewBit())
 	if err != nil {
 		return nil, errors.Wrap(err, "error in encrypt")
 	}
@@ -225,7 +225,7 @@ func (s *LWE) Encrypt(x data.Vector, PK data.Matrix) (data.Vector, error) {
 	// ctLast ... a vector comprising the last l elements of the cipher
 
 	// ct0 = A(transposed) * r
-	ATrans := s.params.A.Transpose()
+	ATrans := s.Params.A.Transpose()
 	ct0, _ := ATrans.MulVec(r)
 
 	// Calculate coordinates ct_last_i = <pkI, r> + t(xi) mod q
@@ -236,7 +236,7 @@ func (s *LWE) Encrypt(x data.Vector, PK data.Matrix) (data.Vector, error) {
 
 	t := s.center(x)
 	ctLast = ctLast.Add(t)
-	ctLast = ctLast.Mod(s.params.q)
+	ctLast = ctLast.Mod(s.Params.Q)
 
 	// Construct the final ciphertext vector by joining both parts
 	return append(ct0, ctLast...), nil
@@ -246,9 +246,9 @@ func (s *LWE) Encrypt(x data.Vector, PK data.Matrix) (data.Vector, error) {
 func (s *LWE) center(v data.Vector) data.Vector {
 	return v.Apply(func(x *big.Int) *big.Int {
 		t := new(big.Int)
-		t.Mul(x, s.params.q)
-		t.Div(t, s.params.p)
-		t.Mod(t, s.params.q)
+		t.Mul(x, s.Params.Q)
+		t.Div(t, s.Params.P)
+		t.Mod(t, s.Params.Q)
 
 		return t
 	})
@@ -259,42 +259,42 @@ func (s *LWE) center(v data.Vector) data.Vector {
 // If decryption failed (for instance with input data that violates the
 // configured bound or malformed ciphertext or keys), error is returned.
 func (s *LWE) Decrypt(ct, skY, y data.Vector) (*big.Int, error) {
-	if err := y.CheckBound(s.params.boundY); err != nil {
+	if err := y.CheckBound(s.Params.BoundY); err != nil {
 		return nil, err
 	}
-	if len(skY) != s.params.n {
+	if len(skY) != s.Params.N {
 		return nil, gofe.MalformedDecKey
 	}
-	if len(y) != s.params.l {
+	if len(y) != s.Params.L {
 		return nil, gofe.MalformedInput
 	}
 
 	// Break down the ciphertext vector into
 	// ct0     which holds first n elements of the cipher, and
 	// ctLast  which holds last n elements of the cipher
-	if len(ct) != s.params.n+s.params.l {
+	if len(ct) != s.Params.N +s.Params.L {
 		return nil, gofe.MalformedCipher
 	}
-	ct0 := ct[:s.params.n]
-	ctLast := ct[s.params.n:]
+	ct0 := ct[:s.Params.N]
+	ctLast := ct[s.Params.N:]
 
 	// Calculate d = <y, ctLast> - <ct0, skY>
 	yDotCtLast, _ := y.Dot(ctLast)
-	yDotCtLast.Mod(yDotCtLast, s.params.q)
+	yDotCtLast.Mod(yDotCtLast, s.Params.Q)
 	ct0DotSkY, _ := ct0.Dot(skY)
-	ct0DotSkY.Mod(ct0DotSkY, s.params.q)
+	ct0DotSkY.Mod(ct0DotSkY, s.Params.Q)
 
-	halfQ := new(big.Int).Div(s.params.q, big.NewInt(2))
+	halfQ := new(big.Int).Div(s.Params.Q, big.NewInt(2))
 
 	// d will hold the decrypted message
 	d := new(big.Int).Sub(yDotCtLast, ct0DotSkY)
 	// in case d > q/2 the result will be negative
 	if d.Cmp(halfQ) == 1 {
-		d.Sub(d, s.params.q)
+		d.Sub(d, s.Params.Q)
 	}
 
-	d.Mul(d, s.params.p)
+	d.Mul(d, s.Params.P)
 	d.Add(d, halfQ)
-	d.Div(d, s.params.q)
+	d.Div(d, s.Params.Q)
 	return d, nil
 }


### PR DESCRIPTION
Scheme parameters (and their fields) made public (uppercase) to enable storage and serialization (for example gob encoding ignores the fields which are not public).

Signed-off-by: Miha Stopar <miha.stopar@xlab.si>