### PR TITLE
Key encapsulation in FAME and GPSW

### DIFF
--- a/abe/fame.go
+++ b/abe/fame.go
@@ -122,7 +122,7 @@ func (a *FAME) Encrypt(msg string, msp *MSP, pk *FAMEPubKey) (*FAMECipher, error
 	}
 
 	// msg is encrypted using CBC, with a random key that is encapsulated
-	// with GPSW
+	// with FAME
 	_, keyGt, err := bn256.RandomGT(rand.Reader)
 	if err != nil {
 		return nil, err
@@ -142,12 +142,9 @@ func (a *FAME) Encrypt(msg string, msp *MSP, pk *FAMEPubKey) (*FAMECipher, error
 	// message is padded according to pkcs7 standard
 	padLen := c.BlockSize() - (len(msgByte) % c.BlockSize())
 	msgPad := make([]byte, len(msgByte)+padLen)
-	for i := 0; i < len(msgPad); i++ {
-		if i < len(msgByte) {
-			msgPad[i] = msgByte[i]
-		} else {
-			msgPad[i] = byte(padLen)
-		}
+	copy(msgPad, msgByte)
+	for i := len(msgByte); i < len(msgPad); i++ {
+		msgPad[i] = byte(padLen)
 	}
 
 	symEnc := make([]byte, len(msgPad))

--- a/abe/fame.go
+++ b/abe/fame.go
@@ -22,6 +22,11 @@ import (
 	"fmt"
 	"strconv"
 
+	"crypto/aes"
+	cbc "crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+
 	"github.com/fentec-project/bn256"
 	"github.com/fentec-project/gofe/data"
 	"github.com/fentec-project/gofe/sample"
@@ -93,6 +98,7 @@ type FAMECipher struct {
 	Ct      [][3]*bn256.G1
 	CtPrime *bn256.GT
 	Msp     *MSP
+	SymEnc  []byte // symmetric encryption of the message
 }
 
 // Encrypt takes as an input a message msg represented as an element of an elliptic
@@ -101,11 +107,6 @@ type FAMECipher struct {
 // is returned. Note that safety of the encryption is only proved if the mapping
 // msp.RowToAttrib from the rows of msp.Mat to attributes is injective.
 func (a *FAME) Encrypt(msg string, msp *MSP, pk *FAMEPubKey) (*FAMECipher, error) {
-	msgInGt, err := bn256.MapStringToGT(msg)
-	if err != nil {
-		return nil, err
-	}
-
 	if len(msp.Mat) == 0 || len(msp.Mat[0]) == 0 {
 		return nil, fmt.Errorf("empty msp matrix")
 	}
@@ -120,6 +121,39 @@ func (a *FAME) Encrypt(msg string, msp *MSP, pk *FAMEPubKey) (*FAMECipher, error
 
 	}
 
+	// msg is encrypted using CBC, with a random key that is encapsulated
+	// with GPSW
+	_, keyGt, err := bn256.RandomGT(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	keyCBC := sha256.Sum256([]byte(keyGt.String()))
+
+	c, err := aes.NewCipher(keyCBC[:])
+	if err != nil {
+		return nil, err
+	}
+
+	iv := make([]byte, c.BlockSize())
+	encrypterCBC := cbc.NewCBCEncrypter(c, iv)
+
+	msgByte := []byte(msg)
+
+	// message is padded according to pkcs7 standard
+	padLen := c.BlockSize() - (len(msgByte) % c.BlockSize())
+	msgPad := make([]byte, len(msgByte)+padLen)
+	for i := 0; i < len(msgPad); i++ {
+		if i < len(msgByte) {
+			msgPad[i] = msgByte[i]
+		} else {
+			msgPad[i] = byte(padLen)
+		}
+	}
+
+	symEnc := make([]byte, len(msgPad))
+	encrypterCBC.CryptBlocks(symEnc, msgPad)
+
+	// encapsulate the key with FAME
 	sampler := sample.NewUniform(a.P)
 	s, err := data.NewRandomVector(2, sampler)
 	if err != nil {
@@ -174,9 +208,9 @@ func (a *FAME) Encrypt(msg string, msp *MSP, pk *FAMEPubKey) (*FAMECipher, error
 
 	ctPrime := new(bn256.GT).ScalarMult(pk.PartGT[0], s[0])
 	ctPrime.Add(ctPrime, new(bn256.GT).ScalarMult(pk.PartGT[1], s[1]))
-	ctPrime.Add(ctPrime, msgInGt)
+	ctPrime.Add(ctPrime, keyGt)
 
-	return &FAMECipher{Ct0: ct0, Ct: ct, CtPrime: ctPrime, Msp: msp}, nil
+	return &FAMECipher{Ct0: ct0, Ct: ct, CtPrime: ctPrime, Msp: msp, SymEnc: symEnc}, nil
 }
 
 // FAMEAttribKeys represents keys corresponding to attributes possessed by
@@ -334,7 +368,8 @@ func (a *FAME) Decrypt(cipher *FAMECipher, key *FAMEAttribKeys, pk *FAMEPubKey) 
 		return "", fmt.Errorf("provided key is not sufficient for decryption")
 	}
 
-	msgInGt := new(bn256.GT).Set(cipher.CtPrime)
+	// get a CBC key needed for the decryption of msg
+	keyGt := new(bn256.GT).Set(cipher.CtPrime)
 
 	ctProd := new([3]*bn256.G1)
 	keyProd := new([3]*bn256.G1)
@@ -349,9 +384,25 @@ func (a *FAME) Decrypt(cipher *FAMECipher, key *FAMEAttribKeys, pk *FAMEPubKey) 
 		ctPairing := bn256.Pair(ctProd[j], key.K0[j])
 		keyPairing := bn256.Pair(keyProd[j], cipher.Ct0[j])
 		keyPairing.Neg(keyPairing)
-		msgInGt.Add(msgInGt, ctPairing)
-		msgInGt.Add(msgInGt, keyPairing)
+		keyGt.Add(keyGt, ctPairing)
+		keyGt.Add(keyGt, keyPairing)
 	}
 
-	return bn256.MapGTToString(msgInGt), nil
+	keyCBC := sha256.Sum256([]byte(keyGt.String()))
+
+	c, err := aes.NewCipher(keyCBC[:])
+	if err != nil {
+		return "", err
+	}
+	iv := make([]byte, c.BlockSize())
+
+	msgPad := make([]byte, len(cipher.SymEnc))
+	decrypter := cbc.NewCBCDecrypter(c, iv)
+	decrypter.CryptBlocks(msgPad, cipher.SymEnc)
+
+	// unpad the message
+	padLen := int(msgPad[len(msgPad)-1])
+	msgByte := msgPad[0:(len(msgPad) - padLen)]
+
+	return string(msgByte), nil
 }

--- a/abe/gpsw.go
+++ b/abe/gpsw.go
@@ -121,12 +121,9 @@ func (a *GPSW) Encrypt(msg string, gamma []int, pk *GPSWPubKey) (*GPSWCipher, er
 	// message is padded according to pkcs7 standard
 	padLen := c.BlockSize() - (len(msgByte) % c.BlockSize())
 	msgPad := make([]byte, len(msgByte)+padLen)
-	for i := 0; i < len(msgPad); i++ {
-		if i < len(msgByte) {
-			msgPad[i] = msgByte[i]
-		} else {
-			msgPad[i] = byte(padLen)
-		}
+	copy(msgPad, msgByte)
+	for i := len(msgByte); i < len(msgPad); i++ {
+		msgPad[i] = byte(padLen)
 	}
 
 	symEnc := make([]byte, len(msgPad))

--- a/abe/gpsw.go
+++ b/abe/gpsw.go
@@ -17,6 +17,10 @@
 package abe
 
 import (
+	"crypto/aes"
+	cbc "crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
 	"fmt"
 	"math/big"
 
@@ -89,25 +93,53 @@ type GPSWCipher struct {
 	AttribToI map[int]int   // a map that connects the attributes in gamma with elements of e
 	E0        *bn256.GT     // the first part of the encryption
 	E         data.VectorG2 // the second part of the encryption
+	SymEnc    []byte        // symmetric encryption of the message
 }
 
 // Encrypt takes as an input a message msg given as a string, gamma a set of
 // attributes that can be latter used in a decryption policy and a public
-// key pk. It returns an encryption of msk. In case of a failed procedure an
+// key pk. It returns an encryption of msg. In case of a failed procedure an
 // error is returned.
 func (a *GPSW) Encrypt(msg string, gamma []int, pk *GPSWPubKey) (*GPSWCipher, error) {
-	msgInGt, err := bn256.MapStringToGT(msg)
+	// msg is encrypted using CBC, with a random key that is encapsulated
+	// with GPSW
+	_, keyGt, err := bn256.RandomGT(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	keyCBC := sha256.Sum256([]byte(keyGt.String()))
+
+	c, err := aes.NewCipher(keyCBC[:])
 	if err != nil {
 		return nil, err
 	}
 
+	iv := make([]byte, c.BlockSize())
+	encrypterCBC := cbc.NewCBCEncrypter(c, iv)
+
+	msgByte := []byte(msg)
+	// message is padded according to pkcs7 standard
+	padLen := c.BlockSize() - (len(msgByte) % c.BlockSize())
+	msgPad := make([]byte, len(msgByte)+padLen)
+	for i := 0; i < len(msgPad); i++ {
+		if i < len(msgByte) {
+			msgPad[i] = msgByte[i]
+		} else {
+			msgPad[i] = byte(padLen)
+		}
+	}
+
+	symEnc := make([]byte, len(msgPad))
+	encrypterCBC.CryptBlocks(symEnc, msgPad)
+
+	// encapsulate the key with GPSW
 	sampler := sample.NewUniform(a.Params.P)
 	s, err := sampler.Sample()
 	if err != nil {
 		return nil, err
 	}
 
-	e0 := new(bn256.GT).Add(msgInGt, new(bn256.GT).ScalarMult(pk.Y, s))
+	e0 := new(bn256.GT).Add(keyGt, new(bn256.GT).ScalarMult(pk.Y, s))
 	e := make(data.VectorG2, len(gamma))
 	attribToI := make(map[int]int)
 	for i, el := range gamma {
@@ -118,7 +150,8 @@ func (a *GPSW) Encrypt(msg string, gamma []int, pk *GPSWPubKey) (*GPSWCipher, er
 	return &GPSWCipher{Gamma: gamma,
 		AttribToI: attribToI,
 		E0:        e0,
-		E:         e}, nil
+		E:         e,
+		SymEnc:    symEnc}, nil
 }
 
 // GeneratePolicyKeys given a monotone span program (MSP) msp and the vector of secret
@@ -233,13 +266,30 @@ func (a *GPSW) Decrypt(cipher *GPSWCipher, key *GPSWKey) (string, error) {
 		return "", fmt.Errorf("the provided key is not sufficient for the decryption")
 	}
 
-	msgInGt := new(bn256.GT).Set(cipher.E0)
+	// get a CBC key needed for the decryption of msg
+	keyGt := new(bn256.GT).Set(cipher.E0)
 	for i := 0; i < len(alpha); i++ {
 		pair := bn256.Pair(key.D[i], cipher.E[cipher.AttribToI[key.RowToAttrib[i]]])
 		pair.ScalarMult(pair, alpha[i])
 		pair.Neg(pair)
-		msgInGt.Add(msgInGt, pair)
+		keyGt.Add(keyGt, pair)
 	}
 
-	return bn256.MapGTToString(msgInGt), nil
+	keyCBC := sha256.Sum256([]byte(keyGt.String()))
+
+	c, err := aes.NewCipher(keyCBC[:])
+	if err != nil {
+		return "", err
+	}
+	iv := make([]byte, c.BlockSize())
+
+	msgPad := make([]byte, len(cipher.SymEnc))
+	decrypter := cbc.NewCBCDecrypter(c, iv)
+	decrypter.CryptBlocks(msgPad, cipher.SymEnc)
+
+	// unpad the message
+	padLen := int(msgPad[len(msgPad)-1])
+	msgByte := msgPad[0:(len(msgPad) - padLen)]
+
+	return string(msgByte), nil
 }

--- a/innerprod/fullysec/damgard_dec_multi.go
+++ b/innerprod/fullysec/damgard_dec_multi.go
@@ -38,11 +38,11 @@ import (
 // Σ_i <x_i, y_i> (sum of dot products).
 type DamgardDecMultiClient struct {
 	// number of encryptors
-	Idx           int
+	Idx int
 	*DamgardMulti
-	ClientPubKey  *big.Int
-	ClientSecKey  *big.Int
-	Share         data.Matrix
+	ClientPubKey *big.Int
+	ClientSecKey *big.Int
+	Share        data.Matrix
 }
 
 // NewDamgardDecMultiClient configures a new client in the decentralized scheme
@@ -60,10 +60,10 @@ func NewDamgardDecMultiClient(idx int, damgardMulti *DamgardMulti) (*DamgardDecM
 	pub := new(big.Int).Exp(damgardMulti.Params.G, sec, damgardMulti.Params.P)
 
 	return &DamgardDecMultiClient{
-		Idx:           idx,
-		DamgardMulti:  damgardMulti,
-		ClientPubKey:  pub,
-		ClientSecKey:  sec,
+		Idx:          idx,
+		DamgardMulti: damgardMulti,
+		ClientPubKey: pub,
+		ClientSecKey: sec,
 	}, nil
 }
 
@@ -80,11 +80,9 @@ func (c *DamgardDecMultiClient) SetShare(pubKeys []*big.Int) error {
 			continue
 		}
 		sharedNum := new(big.Int).Exp(pubKeys[k], c.ClientSecKey, c.Params.P)
-		sharedKey := sha256.New().Sum([]byte(sharedNum.String()))
-		var sharedKeyFixed [32]byte
-		copy(sharedKeyFixed[:], sharedKey)
+		sharedKey := sha256.Sum256([]byte(sharedNum.String()))
 
-		add, err = data.NewRandomDetMatrix(c.NumClients, c.Params.L, c.Params.Q, &sharedKeyFixed)
+		add, err = data.NewRandomDetMatrix(c.NumClients, c.Params.L, c.Params.Q, &sharedKey)
 		if err != nil {
 			return err
 		}

--- a/innerprod/fullysec/dmcfe.go
+++ b/innerprod/fullysec/dmcfe.go
@@ -76,11 +76,9 @@ func (c *DMCFEClient) SetShare(pubKeys []*bn256.G1) error {
 			continue
 		}
 		sharedG1 := new(bn256.G1).ScalarMult(pubKeys[k], c.ClientSecKey)
-		sharedKey := sha256.New().Sum([]byte(sharedG1.String()))
-		var sharedKeyFixed [32]byte
-		copy(sharedKeyFixed[:], sharedKey)
+		sharedKey := sha256.Sum256([]byte(sharedG1.String()))
 
-		add, err = data.NewRandomDetMatrix(2, 2, bn256.Order, &sharedKeyFixed)
+		add, err = data.NewRandomDetMatrix(2, 2, bn256.Order, &sharedKey)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR adds a key encapsulation procedure in ABE schemes FAME and GPSW. In particular the schemes now encrypt the message with a symmetric encryption (CBC) with a random key and use ABE encryption to encrypt the key (encapsulate). This enables to encrypt arbitrary long messages with both schemes.

Additionally a small hashing fix is done in the decentralized inner-product schemes.