### PR TITLE
Function Hiding Inner Product Encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,15 @@ attacks** (s-IND-CPA security):
     * Multi-input scheme based on paper by _Abdalla et.al_ ([paper](https://eprint.iacr.org/2017/972.pdf)) and instantiated from the scheme in the first point (`simple.DDHMulti`).
 
 * Schemes with **adaptive security under chosen-plaintext attacks** (IND-CPA
-security) by 
+security):
     * Scheme based on paper by _Agrawal, Libert and Stehlé_ ([paper](https://eprint.iacr.org/2015/608.pdf)). It can be instantiated from Damgard DDH (`fullysec.Damgard` - similar to `simple.DDH`, but uses one more group element to achieve full security, similar to how Damgård's encryption scheme is obtained from ElGamal scheme ([paper](https://link.springer.com/chapter/10.1007/3-540-46766-1_36)), LWE (`fullysec.LWE`) and Paillier (`fullysec.Paillier`) primitives.
     * Multi-input scheme based on paper by _Abdalla et.al_ ([paper](https://eprint.iacr.org/2017/972.pdf)) and instantiated from the scheme in the first point (`fullysec.DamgardMulti`).
     * Decentralized scheme based on paper by _Chotard, Dufour Sans, Gay, Phan and Pointcheval_ ([paper](https://eprint.iacr.org/2017/989.pdf)). This scheme does not require a trusted party to generate keys. It is built on pairings (`fullysec.DMCFEClient`).
     * Decentralized scheme based on paper by _Abdalla, Benhamouda, Kohlweiss, Waldner_  ([paper](https://eprint.iacr.org/2019/020.pdf)). Similarly as above this scheme this scheme does not require a trusted party to generate keys and is based on a general 
 procedure for decentralization of an inner product scheme, in particular the decentralization of a Damgard DDH scheme (`fullysec.DamgardDecMultiClient`).
+* Schemes with **simulation based security** (SIM-Security for IPE):
+    * Function hiding inner product scheme by _Kim, Lewi, Mandal, Montgomery, Roy, Wu_ ([paper](https://eprint.iacr.org/2016/440.pdf)). The scheme allows the decryptor to
+decrypt the inner product of x and y without reveling (ciphertext) x or (function) y (`fullysec.fhipe`).
 
 #### Quadratic polynomial schemes
 You will need `SGP` scheme from package `quadratic`. 

--- a/abe/fame.go
+++ b/abe/fame.go
@@ -367,7 +367,7 @@ func (a *FAME) Decrypt(cipher *FAMECipher, key *FAMEAttribKeys, pk *FAMEPubKey) 
 	// get a combination alpha of keys needed to decrypt
 	oneVec := data.NewConstantVector(len(matForKey[0]), big.NewInt(0))
 	oneVec[0].SetInt64(1)
-	alpha, err := gaussianElimination(matForKey.Transpose(), oneVec, a.P)
+	alpha, err := data.GaussianEliminationSolver(matForKey.Transpose(), oneVec, a.P)
 	if err != nil {
 		return "", fmt.Errorf("provided key is not sufficient for decryption")
 	}

--- a/abe/gpsw.go
+++ b/abe/gpsw.go
@@ -266,7 +266,7 @@ func (a *GPSW) DelegateKeys(keys data.VectorG1, msp *MSP, attrib []int) *GPSWKey
 func (a *GPSW) Decrypt(cipher *GPSWCipher, key *GPSWKey) (string, error) {
 	// get a combination alpha of keys needed to decrypt
 	ones := data.NewConstantVector(len(key.Mat[0]), big.NewInt(1))
-	alpha, err := gaussianElimination(key.Mat.Transpose(), ones, a.Params.P)
+	alpha, err := data.GaussianEliminationSolver(key.Mat.Transpose(), ones, a.Params.P)
 	if err != nil {
 		return "", fmt.Errorf("the provided key is not sufficient for the decryption")
 	}

--- a/abe/policy_test.go
+++ b/abe/policy_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/fentec-project/gofe/data"
-	"github.com/fentec-project/gofe/sample"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -44,7 +43,7 @@ func TestBooleanToMsp(t *testing.T) {
 	m[1] = msp.Mat[2]
 	m[2] = msp.Mat[4]
 
-	x, err := gaussianElimination(m.Transpose(), v, p)
+	x, err := data.GaussianEliminationSolver(m.Transpose(), v, p)
 	if err != nil {
 		t.Fatalf("Error finding a vector: %v", err)
 	}
@@ -52,56 +51,5 @@ func TestBooleanToMsp(t *testing.T) {
 
 	// check if an error is generated if the boolean expression is not in a correct form
 	_, err = BooleanToMSP("1 AND ((6 OR 7) AND (8 OR 9)) OR ((2 AND 3) OR (4 AND 5)))", true)
-	assert.Error(t, err)
-
-}
-
-func TestGaussianElimintaion(t *testing.T) {
-	// create instances mat, xTest and v for which mat * xTest = v
-	// as a matrix vector multiplication over Z_p
-
-	p := big.NewInt(17)
-	sampler := sample.NewUniform(p)
-	mat, err := data.NewRandomMatrix(100, 50, sampler)
-	if err != nil {
-		t.Fatalf("Error during matrix generation: %v", err)
-	}
-
-	xTest, err := data.NewRandomVector(50, sampler)
-	if err != nil {
-		t.Fatalf("Error during vector generation: %v", err)
-	}
-
-	v, err := mat.MulVec(xTest)
-	if err != nil {
-		t.Fatalf("Error in generating a test vector: %v", err)
-	}
-	v = v.Mod(p)
-
-	// test the Gaussian elimination algorithm that given v and mat
-	// finds x such that mat * x = v
-	x, err := gaussianElimination(mat, v, p)
-	if err != nil {
-		t.Fatalf("Error in Gaussian elimination: %v", err)
-	}
-
-	// test if the obtained x is correct
-	vCheck, err := mat.MulVec(x)
-	if err != nil {
-		t.Fatalf("Error obtainig a check value: %v", err)
-	}
-	vCheck = vCheck.Mod(p)
-	assert.Equal(t, v, vCheck)
-
-	// test if errors are returned if the inputs have a wrong form
-	vWrong, err := data.NewRandomVector(101, sampler)
-	if err != nil {
-		t.Fatalf("Error during vector generation: %v", err)
-	}
-	_, err = gaussianElimination(mat, vWrong, p)
-	assert.Error(t, err)
-
-	matWrong := make(data.Matrix, 0)
-	_, err = gaussianElimination(matWrong, v, p)
 	assert.Error(t, err)
 }

--- a/data/matrix.go
+++ b/data/matrix.go
@@ -559,7 +559,7 @@ func (mat Matrix) GaussianElimination(p *big.Int) (Matrix, error) {
 
 // InverseModGauss returns the inverse matrix of m in the group Z_p.
 // The algorithm uses Gaussian elimination. It returns the determinant
-// as well. in case the matrix is not invertible it returns an error.
+// as well. In case the matrix is not invertible it returns an error.
 func (mat Matrix) InverseModGauss(p *big.Int) (Matrix, *big.Int, error) {
 	if mat.Rows() == 0 || mat.Cols() == 0 {
 		return nil, nil, fmt.Errorf("the matrix should not be empty")
@@ -641,7 +641,7 @@ func (m Matrix) DeterminantGauss(p *big.Int) (*big.Int, error) {
 	return ret, nil
 }
 
-// gaussianEliminationSolver solves a vector equation mat * x = v and finds vector x,
+// GaussianEliminationSolver solves a vector equation mat * x = v and finds vector x,
 // using Gaussian elimination. Arithmetic operations are considered to be over
 // Z_p, where p should be a prime number. If such x does not exist, then the
 // function returns an error.

--- a/data/matrix.go
+++ b/data/matrix.go
@@ -378,6 +378,10 @@ func (m Matrix) InverseMod(p *big.Int) (Matrix, error) {
 		return nil, fmt.Errorf("matrix non-invertable")
 	}
 	invDet := new(big.Int).ModInverse(det, p)
+	if m.Rows() == 1 {
+		mat[0] = Vector{invDet}
+		return mat, nil
+	}
 	sign := new(big.Int)
 	minusOne := big.NewInt(-1)
 	for i := 0; i < m.Rows(); i++ {
@@ -504,4 +508,218 @@ func (m Matrix) MatMulVecG2(other VectorG2) (VectorG2, error) {
 	}
 
 	return prod, nil
+}
+
+// GaussianElimination uses Gaussian elimination to transform a matrix
+// into an equivalent upper triangular form
+func (mat Matrix) GaussianElimination(p *big.Int) (Matrix, error) {
+	if len(mat) == 0 || len(mat[0]) == 0 {
+		return nil, fmt.Errorf("the matrix should not be empty")
+	}
+
+	// we copy matrix mat into m and v into u
+	m := make(Matrix, len(mat))
+	for i := 0; i < len(mat); i++ {
+		m[i] = make(Vector, len(mat[0]))
+		for j := 0; j < len(mat[0]); j++ {
+			m[i][j] = new(big.Int).Set(mat[i][j])
+		}
+	}
+
+	// m and u are transformed to be in the upper triangular form
+	h, k := 0, 0
+	for h < len(m) && k < len(m[0]) {
+		zero := true
+		for i := h; i < len(m); i++ {
+			if m[i][k].Sign() != 0 {
+				m[h], m[i] = m[i], m[h]
+				zero = false
+				break
+			}
+		}
+		if zero {
+			k++
+			continue
+		}
+		mHKInv := new(big.Int).ModInverse(m[h][k], p)
+		for i := h + 1; i < len(m); i++ {
+			f := new(big.Int).Mul(mHKInv, m[i][k])
+			m[i][k] = big.NewInt(0)
+			for j := k + 1; j < len(m[0]); j++ {
+				m[i][j].Sub(m[i][j], new(big.Int).Mul(f, m[h][j]))
+				m[i][j].Mod(m[i][j], p)
+			}
+		}
+		k++
+		h++
+	}
+
+	return m, nil
+}
+
+// InverseModGauss returns the inverse matrix of m in the group Z_p.
+// The algorithm uses Gaussian elimination.
+//
+// It returns an error in case the matrix is not invertible.
+func (mat Matrix) InverseModGauss(p *big.Int) (Matrix, *big.Int, error) {
+	if len(mat) == 0 || len(mat[0]) == 0 {
+		return nil, nil, fmt.Errorf("the matrix should not be empty")
+	}
+
+	// we copy matrix mat into matExt and extend it with identity
+	matExt := make(Matrix, len(mat))
+	for i := 0; i < len(mat); i++ {
+		matExt[i] = make(Vector, len(mat[0])*2)
+		for j := 0; j < len(mat[0]); j++ {
+			matExt[i][j] = new(big.Int).Set(mat[i][j])
+		}
+		for j := len(mat[0]); j < 2*len(mat[0]); j++ {
+			if i+len(mat[0]) == j {
+				matExt[i][j] = big.NewInt(1)
+			} else {
+				matExt[i][j] = big.NewInt(0)
+			}
+
+		}
+	}
+
+	triang, err := matExt.GaussianElimination(p)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// check if the inverse can be computed
+	det := big.NewInt(1)
+	for i := 0; i < matExt.Rows(); i++ {
+		det.Mul(det, triang[i][i])
+		det.Mod(det, p)
+	}
+	if det.Sign() == 0 {
+		return nil, nil, fmt.Errorf("matrix non-invertable")
+	}
+
+	// use the upper triangular form to obtain the solution
+	matInv := make(Matrix, len(mat))
+	for k := 0; k < len(mat); k++ {
+		matInv[k] = make(Vector, len(mat[0]))
+		for i := len(mat) - 1; i >= 0; i-- {
+			for j := len(mat) - 1; j >= 0; j-- {
+				if matInv[k][j] == nil {
+					tmpSum, _ := triang[i][j+1:len(mat[0])].Dot(matInv[k][j+1:])
+					matInv[k][j] = new(big.Int).Sub(triang[i][len(mat[0])+k], tmpSum)
+					mHKInv := new(big.Int).ModInverse(triang[i][j], p)
+					matInv[k][j].Mul(matInv[k][j], mHKInv)
+					matInv[k][j].Mod(matInv[k][j], p)
+					break
+				}
+			}
+		}
+	}
+
+	return matInv.Transpose(), det, nil
+}
+
+// DeterminantGauss returns the determinant of matrix m using Gaussian
+// elimination. It returns an error if the determinant does not exist.
+func (m Matrix) DeterminantGauss(p *big.Int) (*big.Int, error) {
+	if m.Rows() != m.Cols() {
+		return nil, fmt.Errorf("number of rows must equal number of columns")
+	}
+	triang, err := m.GaussianElimination(p)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := big.NewInt(1)
+	for i := 0; i < m.Cols(); i++ {
+		ret.Mul(ret, triang[i][i])
+		ret.Mod(ret, p)
+	}
+
+	return ret, nil
+}
+
+// gaussianEliminationSolver solves a vector equation mat * x = v and finds vector x,
+// using Gaussian elimination. Arithmetic operations are considered to be over
+// Z_p, where p should be a prime number. If such x does not exist, then the
+// function returns an error.
+func GaussianEliminationSolver(mat Matrix, v Vector, p *big.Int) (Vector, error) {
+	if len(mat) == 0 || len(mat[0]) == 0 {
+		return nil, fmt.Errorf("the matrix should not be empty")
+	}
+	if len(mat) != len(v) {
+		return nil, fmt.Errorf(fmt.Sprintf("dimensions should match: "+
+			"rows of the matrix %d, length of the vector %d", len(mat), len(v)))
+	}
+
+	// we copy matrix mat into m and v into u
+	cpMat := make([]Vector, len(mat))
+	u := make(Vector, len(mat))
+	for i := 0; i < len(mat); i++ {
+		cpMat[i] = make(Vector, len(mat[0]))
+		for j := 0; j < len(mat[0]); j++ {
+			cpMat[i][j] = new(big.Int).Set(mat[i][j])
+		}
+		u[i] = new(big.Int).Set(v[i])
+	}
+	m, _ := NewMatrix(cpMat) // error is impossible to happen
+
+	// m and u are transformed to be in the upper triangular form
+	ret := make(Vector, len(mat[0]))
+	h, k := 0, 0
+	for h < len(m) && k < len(m[0]) {
+		zero := true
+		for i := h; i < len(m); i++ {
+			if m[i][k].Sign() != 0 {
+				m[h], m[i] = m[i], m[h]
+
+				u[h], u[i] = u[i], u[h]
+				zero = false
+				break
+			}
+		}
+		if zero {
+			ret[k] = big.NewInt(0)
+			k++
+			continue
+		}
+		mHKInv := new(big.Int).ModInverse(m[h][k], p)
+		for i := h + 1; i < len(m); i++ {
+			f := new(big.Int).Mul(mHKInv, m[i][k])
+			m[i][k] = big.NewInt(0)
+			for j := k + 1; j < len(m[0]); j++ {
+				m[i][j].Sub(m[i][j], new(big.Int).Mul(f, m[h][j]))
+				m[i][j].Mod(m[i][j], p)
+			}
+			u[i].Sub(u[i], new(big.Int).Mul(f, u[h]))
+			u[i].Mod(u[i], p)
+		}
+		k++
+		h++
+	}
+
+	for i := h; i < len(m); i++ {
+		if u[i].Sign() != 0 {
+			return nil, fmt.Errorf("no solution")
+		}
+	}
+	for j := k; j < len(m[0]); j++ {
+		ret[j] = big.NewInt(0)
+	}
+
+	// use the upper triangular form to obtain the solution
+	for i := h - 1; i >= 0; i-- {
+		for j := k - 1; j >= 0; j-- {
+			if ret[j] == nil {
+				tmpSum, _ := m[i][j+1:].Dot(ret[j+1:])
+				ret[j] = new(big.Int).Sub(u[i], tmpSum)
+				mHKInv := new(big.Int).ModInverse(m[i][j], p)
+				ret[j].Mul(ret[j], mHKInv)
+				ret[j].Mod(ret[j], p)
+				break
+			}
+		}
+	}
+
+	return ret, nil
 }

--- a/innerprod/fullysec/fhipe.go
+++ b/innerprod/fullysec/fhipe.go
@@ -29,34 +29,33 @@ import (
 )
 
 // L (int): The length of vectors to be encrypted.
-// Bound (int): The value by which coordinates of vectors x and y are bounded.
-// G (int): Generator of a cyclic group Z_P: G**(Q) = 1 (mod P).
-// H (int): Generator of a cyclic group Z_P: H**(Q) = 1 (mod P).
-// P (int): Modulus - we are operating in a cyclic group Z_P.
-// Q (int): Multiplicative order of G and H.
+// BoundX (int): The value by which coordinates of encrypted vectors x are bounded.
+// BoundY (int): The value by which coordinates of inner product vectors y are bounded.
 type FHIPEParams struct {
 	L      int
 	BoundX *big.Int
 	BoundY *big.Int
 }
 
-// Damgard represents a scheme instantiated from the DDH assumption
-// based on DDH variant of:
-// Agrawal, Shweta, Libert, and Stehle:
-// "Fully secure functional encryption for inner products,
-// from standard assumptions".
+// FHIPE represents a Function Hiding Inner Product Encryption scheme
+// based on the paper by Kim, Lewi, Mandal, Montgomery, Roy, Wu:
+// "Function-Hiding Inner Product Encryption is Practical".
+// It allows to encrypt a vector x and generate a secret key based
+// in an inner product vector y so that a deryptor can decrypt the
+// inner product <x,y> without revealing x or y.
+// The struct contains the shared choice for parameters on which
+// the functionality of the scheme depend.
 type FHIPE struct {
 	Params *FHIPEParams
 }
 
-// NewDamgard configures a new instance of the scheme.
-// It accepts the length of input vectors l, the bit length of the
-// modulus (we are operating in the Z_p group), and a bound by which
-// coordinates of input vectors are bounded.
+// NewFHIPE configures a new instance of the scheme.
+// It accepts the length of input vectors l, a bound by which
+// the coordinates of encryption vectors are bounded, and similarly a
+// bound by which the coordinates of inner product vectors are bounded.
 //
 // It returns an error in case the scheme could not be properly
-// configured, or if precondition l * bound² is >= order of the cyclic
-// group.
+// configured, or if the possible decryption value is to big.
 func NewFHIPE(l int, boundX, boundY *big.Int) (*FHIPE, error) {
 	boundXY := new(big.Int).Mul(boundX, boundY)
 	prod := new(big.Int).Mul(big.NewInt(int64(2*l)), boundXY)
@@ -71,16 +70,16 @@ func NewFHIPE(l int, boundX, boundY *big.Int) (*FHIPE, error) {
 			BoundY: boundY}}, nil
 }
 
-// NewDamgardFromParams takes configuration parameters of an existing
-// Damgard scheme instance, and reconstructs the scheme with same configuration
-// parameters. It returns a new Damgard instance.
+// NewFHIPEFromParams takes configuration parameters of an existing
+// FHIPE scheme instance, and reconstructs the scheme with same configuration
+// parameters. It returns a new FHIPE instance.
 func NewFHIPEFromParams(params *FHIPEParams) *FHIPE {
 	return &FHIPE{
 		Params: params,
 	}
 }
 
-// DamgardSecKey is a secret key for Damgard scheme.
+// FHIPESecKey is a secret key for FHIPE scheme.
 type FHIPESecKey struct {
 	G1    *bn256.G1
 	G2    *bn256.G2
@@ -88,9 +87,8 @@ type FHIPESecKey struct {
 	BStar data.Matrix
 }
 
-// GenerateMasterKeys generates a master secret key and master
-// public key for the scheme. It returns an error in case master keys
-// could not be generated.
+// GenerateMasterKey generates a master secret key for the scheme.
+// It returns an error in case master key could not be generated.
 func (d *FHIPE) GenerateMasterKey() (*FHIPESecKey, error) {
 	_, g1, err := bn256.RandomG1(rand.Reader)
 	if err != nil {
@@ -112,23 +110,19 @@ func (d *FHIPE) GenerateMasterKey() (*FHIPESecKey, error) {
 		return nil, err
 	}
 	bStar = bStar.Transpose()
-
-	if err != nil {
-		return nil, err
-	}
 	bStar = bStar.MulScalar(det)
 	bStar = bStar.Mod(bn256.Order)
 
 	return &FHIPESecKey{G1: g1, G2: g2, B: b, BStar: bStar}, nil
 }
 
-// DamgardDerivedKey is a functional encryption key for Damgard scheme.
+// FHIPEDerivedKey is a functional encryption key for FHIPE scheme.
 type FHIPEDerivedKey struct {
 	K1 *bn256.G1
 	K2 data.VectorG1
 }
 
-// DeriveKey takes master secret key and input vector y, and returns the
+// DeriveKey takes a master key and input vector y, and returns a
 // functional encryption key. In case the key could not be derived, it
 // returns an error.
 func (d *FHIPE) DeriveKey(y data.Vector, masterKey *FHIPESecKey) (*FHIPEDerivedKey, error) {
@@ -138,6 +132,9 @@ func (d *FHIPE) DeriveKey(y data.Vector, masterKey *FHIPESecKey) (*FHIPEDerivedK
 	if len(y) != d.Params.L {
 		return nil, fmt.Errorf("vector dimension error")
 	}
+	if masterKey.B.Rows() != d.Params.L {
+		return nil, fmt.Errorf("master key dimensions error")
+	}
 
 	sampler := sample.NewUniform(bn256.Order)
 	alpha, err := sampler.Sample()
@@ -146,15 +143,19 @@ func (d *FHIPE) DeriveKey(y data.Vector, masterKey *FHIPESecKey) (*FHIPEDerivedK
 	}
 
 	det, err := masterKey.B.DeterminantGauss(bn256.Order)
-	det.Mod(det, bn256.Order)
 	if err != nil {
 		return nil, err
 	}
+
 	k1 := new(bn256.G1).ScalarMult(masterKey.G1, det)
 	k1.ScalarMult(k1, alpha)
 
 	alphaBY, err := masterKey.B.MulVec(y)
+	if err != nil {
+		return nil, err
+	}
 	alphaBY = alphaBY.MulScalar(alpha)
+	alphaBY = alphaBY.Mod(bn256.Order)
 	g1Vec := make(data.VectorG1, d.Params.L)
 	for i := 0; i < d.Params.L; i++ {
 		g1Vec[i] = new(bn256.G1).Set(masterKey.G1)
@@ -164,20 +165,23 @@ func (d *FHIPE) DeriveKey(y data.Vector, masterKey *FHIPESecKey) (*FHIPEDerivedK
 	return &FHIPEDerivedKey{K1: k1, K2: k2}, nil
 }
 
-// DamgardDerivedKey is a functional encryption key for Damgard scheme.
+// FHIPECipher is a functional encryption key for FHIPE scheme.
 type FHIPECipher struct {
 	C1 *bn256.G2
 	C2 data.VectorG2
 }
 
-// Encrypt encrypts input vector x with the provided master public key.
-// It returns a ciphertext vector. If encryption failed, error is returned.
+// Encrypt encrypts input vector x with the provided master key and returns a ciphertext.
+// If encryption failed, error is returned.
 func (d *FHIPE) Encrypt(x data.Vector, masterKey *FHIPESecKey) (*FHIPECipher, error) {
 	if err := x.CheckBound(d.Params.BoundX); err != nil {
 		return nil, err
 	}
 	if len(x) != d.Params.L {
 		return nil, fmt.Errorf("vector dimension error")
+	}
+	if masterKey.B.Rows() != d.Params.L {
+		return nil, fmt.Errorf("master key dimensions error")
 	}
 
 	sampler := sample.NewUniform(bn256.Order)
@@ -189,7 +193,11 @@ func (d *FHIPE) Encrypt(x data.Vector, masterKey *FHIPESecKey) (*FHIPECipher, er
 	c1 := new(bn256.G2).ScalarMult(masterKey.G2, beta)
 
 	betaBStarX, err := masterKey.BStar.MulVec(x)
+	if err != nil {
+		return nil, err
+	}
 	betaBStarX = betaBStarX.MulScalar(beta)
+	betaBStarX = betaBStarX.Mod(bn256.Order)
 	g2Vec := make(data.VectorG2, d.Params.L)
 	for i := 0; i < d.Params.L; i++ {
 		g2Vec[i] = new(bn256.G2).Set(masterKey.G2)
@@ -199,9 +207,9 @@ func (d *FHIPE) Encrypt(x data.Vector, masterKey *FHIPESecKey) (*FHIPECipher, er
 	return &FHIPECipher{C1: c1, C2: c2}, nil
 }
 
-// Decrypt accepts the encrypted vector, functional encryption key, and
-// a plaintext vector y. It returns the inner product of x and y.
-// If decryption failed, error is returned.
+// Decrypt accepts the ciphertext and functional encryption key.
+// It returns the inner product of x and y. If decryption failed,
+// an error is returned.
 func (d *FHIPE) Decrypt(cipher *FHIPECipher, key *FHIPEDerivedKey) (*big.Int, error) {
 	if len(cipher.C2) != d.Params.L || len(key.K2) != d.Params.L {
 		return nil, fmt.Errorf("key or cipher length error")
@@ -216,6 +224,8 @@ func (d *FHIPE) Decrypt(cipher *FHIPECipher, key *FHIPEDerivedKey) (*big.Int, er
 
 	}
 
+	// calculate the upper bound of the result needed for the
+	// discrete logarithm computation
 	boundXY := new(big.Int).Mul(d.Params.BoundX, d.Params.BoundY)
 	bound := new(big.Int).Mul(big.NewInt(int64(d.Params.L)), boundXY)
 

--- a/innerprod/fullysec/fhipe.go
+++ b/innerprod/fullysec/fhipe.go
@@ -40,8 +40,8 @@ type FHIPEParams struct {
 // FHIPE represents a Function Hiding Inner Product Encryption scheme
 // based on the paper by Kim, Lewi, Mandal, Montgomery, Roy, Wu:
 // "Function-Hiding Inner Product Encryption is Practical".
-// It allows to encrypt a vector x and generate a secret key based
-// in an inner product vector y so that a deryptor can decrypt the
+// It allows to encrypt a vector x and derive a secret key based
+// on an inner product vector y so that a deryptor can decrypt the
 // inner product <x,y> without revealing x or y.
 // The struct contains the shared choice for parameters on which
 // the functionality of the scheme depend.
@@ -165,7 +165,7 @@ func (d *FHIPE) DeriveKey(y data.Vector, masterKey *FHIPESecKey) (*FHIPEDerivedK
 	return &FHIPEDerivedKey{K1: k1, K2: k2}, nil
 }
 
-// FHIPECipher is a functional encryption key for FHIPE scheme.
+// FHIPECipher is a functional encryption ciphertext for FHIPE scheme.
 type FHIPECipher struct {
 	C1 *bn256.G2
 	C2 data.VectorG2

--- a/innerprod/fullysec/fhipe.go
+++ b/innerprod/fullysec/fhipe.go
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2018 XLAB d.o.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fullysec
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/fentec-project/gofe/data"
+	"github.com/fentec-project/gofe/internal"
+	"github.com/fentec-project/gofe/internal/dlog"
+	"github.com/fentec-project/gofe/internal/keygen"
+	emmy "github.com/xlab-si/emmy/crypto/common"
+	"github.com/fentec-project/bn256"
+	"crypto/rand"
+	"github.com/fentec-project/gofe/sample"
+)
+
+// L (int): The length of vectors to be encrypted.
+// Bound (int): The value by which coordinates of vectors x and y are bounded.
+// G (int): Generator of a cyclic group Z_P: G**(Q) = 1 (mod P).
+// H (int): Generator of a cyclic group Z_P: H**(Q) = 1 (mod P).
+// P (int): Modulus - we are operating in a cyclic group Z_P.
+// Q (int): Multiplicative order of G and H.
+type FHIPEParams struct {
+	L     int
+	Bound *big.Int
+}
+
+// Damgard represents a scheme instantiated from the DDH assumption
+// based on DDH variant of:
+// Agrawal, Shweta, Libert, and Stehle:
+// "Fully secure functional encryption for inner products,
+// from standard assumptions".
+type FHIPE struct {
+	Params *FHIPEParams
+}
+
+// NewDamgard configures a new instance of the scheme.
+// It accepts the length of input vectors l, the bit length of the
+// modulus (we are operating in the Z_p group), and a bound by which
+// coordinates of input vectors are bounded.
+//
+// It returns an error in case the scheme could not be properly
+// configured, or if precondition l * bound² is >= order of the cyclic
+// group.
+func NewFHIPE(l int, bound *big.Int) (*FHIPE, error) {
+	bSquared := new(big.Int).Exp(bound, big.NewInt(2), nil)
+	prod := new(big.Int).Mul(big.NewInt(int64(2*l)), bSquared)
+	if prod.Cmp(bn256.Order) > 0 {
+		return nil, fmt.Errorf("2 * l * bound^2 should be smaller than group order")
+	}
+
+	return &FHIPE{
+		Params: &FHIPEParams{
+			L:     l,
+			Bound: bound}}, nil
+}
+
+// NewDamgardFromParams takes configuration parameters of an existing
+// Damgard scheme instance, and reconstructs the scheme with same configuration
+// parameters. It returns a new Damgard instance.
+func NewFHIPEFromParams(params *FHIPEParams) *FHIPE {
+	return &FHIPE{
+		Params: params,
+	}
+}
+
+// DamgardSecKey is a secret key for Damgard scheme.
+type FHIPESecKey struct {
+	G1 *bn256.G1
+	G2 *bn256.G2
+	B data.Matrix
+	BStar data.Matrix
+}
+
+// GenerateMasterKeys generates a master secret key and master
+// public key for the scheme. It returns an error in case master keys
+// could not be generated.
+func (d *FHIPE) GenerateMasterKey() (*FHIPESecKey, error) {
+	_, g1, err := bn256.RandomG1(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	_, g2, err := bn256.RandomG2(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	sampler := sample.NewUniform(bn256.Order)
+	b, err := data.NewRandomMatrix(d.Params.L, d.Params.L, sampler)
+	if err != nil {
+		return nil, err
+	}
+
+	bStar, err := b.InverseMod(bn256.Order)
+	if err != nil {
+		return nil, err
+	}
+	bStar = bStar.Transpose()
+	det, err := bStar.Determinant()
+	if err != nil {
+		return nil, err
+	}
+	bStar = bStar.MulScalar(det)
+	bStar = bStar.Mod(bn256.Order)
+
+	return &FHIPESecKey{G1: g1, G2: g2, B: b, BStar: bStar}, nil
+}
+
+// DamgardDerivedKey is a functional encryption key for Damgard scheme.
+type FHIPEDerivedKey struct {
+	K1 *bn256.G1
+	K2 data.VectorG1
+}
+
+// DeriveKey takes master secret key and input vector y, and returns the
+// functional encryption key. In case the key could not be derived, it
+// returns an error.
+func (d *FHIPE) DeriveKey(masterKey *FHIPESecKey, y data.Vector) (*FHIPEDerivedKey, error) {
+	if err := y.CheckBound(d.Params.Bound); err != nil {
+		return nil, err
+	}
+	if len(y) != d.Params.L {
+		return nil, fmt.Errorf("vector dimension error")
+	}
+
+	sampler := sample.NewUniform(bn256.Order)
+	alpha, err := sampler.Sample()
+	if err != nil {
+		return nil, err
+	}
+
+	det, err := masterKey.B.Determinant()
+	if err != nil {
+		return nil, err
+	}
+	k1 := new(bn256.G1).ScalarMult(masterKey.G1, det)
+	k1.ScalarMult(k1, alpha)
+
+	alphaBY, err := masterKey.B.MulVec(y)
+	alphaBY = alphaBY.MulScalar(alpha)
+
+
+	return &DamgardDerivedKey{Key1: k1, Key2: k2}, nil
+}
+
+// Encrypt encrypts input vector x with the provided master public key.
+// It returns a ciphertext vector. If encryption failed, error is returned.
+func (d *Damgard) Encrypt(x, masterPubKey data.Vector) (data.Vector, error) {
+	if err := x.CheckBound(d.Params.Bound); err != nil {
+		return nil, err
+	}
+
+	r, err := emmy.GetRandomIntFromRange(big.NewInt(2), d.Params.Q)
+	if err != nil {
+		return nil, err
+	}
+
+	ciphertext := make([]*big.Int, len(x)+2)
+	// c = g^r
+	// dd = h^r
+	c := new(big.Int).Exp(d.Params.G, r, d.Params.P)
+	ciphertext[0] = c
+	dd := new(big.Int).Exp(d.Params.H, r, d.Params.P)
+	ciphertext[1] = dd
+
+	for i := 0; i < len(x); i++ {
+		// e_i = h_i^r * g^x_i
+		// e_i = mpk[i]^r * g^x_i
+		t1 := new(big.Int).Exp(masterPubKey[i], r, d.Params.P)
+		t2 := internal.ModExp(d.Params.G, x[i], d.Params.P)
+		ct := new(big.Int).Mod(new(big.Int).Mul(t1, t2), d.Params.P)
+		ciphertext[i+2] = ct
+	}
+
+	return data.NewVector(ciphertext), nil
+}
+
+// Decrypt accepts the encrypted vector, functional encryption key, and
+// a plaintext vector y. It returns the inner product of x and y.
+// If decryption failed, error is returned.
+func (d *Damgard) Decrypt(cipher data.Vector, key *DamgardDerivedKey, y data.Vector) (*big.Int, error) {
+	if err := y.CheckBound(d.Params.Bound); err != nil {
+		return nil, err
+	}
+
+	num := big.NewInt(1)
+	for i, ct := range cipher[2:] {
+		t1 := internal.ModExp(ct, y[i], d.Params.P)
+		num = num.Mod(new(big.Int).Mul(num, t1), d.Params.P)
+	}
+
+	t1 := new(big.Int).Exp(cipher[0], key.Key1, d.Params.P)
+	t2 := new(big.Int).Exp(cipher[1], key.Key2, d.Params.P)
+
+	denom := new(big.Int).Mod(new(big.Int).Mul(t1, t2), d.Params.P)
+	denomInv := new(big.Int).ModInverse(denom, d.Params.P)
+	r := new(big.Int).Mod(new(big.Int).Mul(num, denomInv), d.Params.P)
+
+	bSquared := new(big.Int).Exp(d.Params.Bound, big.NewInt(2), big.NewInt(0))
+	bound := new(big.Int).Mul(big.NewInt(int64(d.Params.L)), bSquared)
+
+	calc, err := dlog.NewCalc().InZp(d.Params.P, d.Params.Q)
+	if err != nil {
+		return nil, err
+	}
+	calc = calc.WithNeg()
+
+	res, err := calc.WithBound(bound).BabyStepGiantStep(r, d.Params.G)
+	return res, err
+}

--- a/innerprod/fullysec/fhipe_test.go
+++ b/innerprod/fullysec/fhipe_test.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2018 XLAB d.o.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fullysec_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/fentec-project/gofe/data"
+	"github.com/fentec-project/gofe/innerprod/fullysec"
+	"github.com/fentec-project/gofe/sample"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFHIPE(t *testing.T) {
+	l := 30
+	bound := big.NewInt(128)
+	//sampler := sample.NewUniformRange(new(big.Int).Neg(bound), bound)
+	sampler := sample.NewUniform(bound)
+
+	fhipe, err := fullysec.NewFHIPE(l, bound, bound)
+	if err != nil {
+		t.Fatalf("Error during simple inner product creation: %v", err)
+	}
+
+	masterSecKey, err := fhipe.GenerateMasterKey()
+	if err != nil {
+		t.Fatalf("Error during master key generation: %v", err)
+	}
+
+	y, err := data.NewRandomVector(l, sampler)
+	if err != nil {
+		t.Fatalf("Error during random generation: %v", err)
+	}
+
+	key, err := fhipe.DeriveKey(y, masterSecKey)
+	if err != nil {
+		t.Fatalf("Error during key derivation: %v", err)
+	}
+
+	x, err := data.NewRandomVector(l, sampler)
+	if err != nil {
+		t.Fatalf("Error during random generation: %v", err)
+	}
+
+	// simulate the instantiation of encryptor (which should be given masterPubKey)
+	encryptor := fullysec.NewFHIPEFromParams(fhipe.Params)
+	ciphertext, err := encryptor.Encrypt(x, masterSecKey)
+	if err != nil {
+		t.Fatalf("Error during encryption: %v", err)
+	}
+
+	decryptor := fullysec.NewFHIPEFromParams(fhipe.Params)
+	xy, err := decryptor.Decrypt(ciphertext, key)
+	if err != nil {
+		t.Fatalf("Error during decryption: %v", err)
+	}
+
+	xyCheck, err := x.Dot(y)
+	if err != nil {
+		t.Fatalf("Error during inner product calculation")
+	}
+	assert.Equal(t, xy.Cmp(xyCheck), 0, "obtained incorrect inner product")
+}

--- a/innerprod/fullysec/fhipe_test.go
+++ b/innerprod/fullysec/fhipe_test.go
@@ -22,54 +22,63 @@ import (
 
 	"github.com/fentec-project/gofe/data"
 	"github.com/fentec-project/gofe/innerprod/fullysec"
-	"github.com/fentec-project/gofe/sample"
 	"github.com/stretchr/testify/assert"
+	"github.com/fentec-project/gofe/sample"
 )
 
 func TestFHIPE(t *testing.T) {
+	// choose the parameters for the encryption and build the scheme
 	l := 30
 	bound := big.NewInt(128)
-	//sampler := sample.NewUniformRange(new(big.Int).Neg(bound), bound)
-	sampler := sample.NewUniform(bound)
 
 	fhipe, err := fullysec.NewFHIPE(l, bound, bound)
 	if err != nil {
-		t.Fatalf("Error during simple inner product creation: %v", err)
+		t.Fatalf("Error during scheme creation: %v", err)
 	}
 
+	// generate master key
 	masterSecKey, err := fhipe.GenerateMasterKey()
 	if err != nil {
 		t.Fatalf("Error during master key generation: %v", err)
 	}
 
-	y, err := data.NewRandomVector(l, sampler)
-	if err != nil {
-		t.Fatalf("Error during random generation: %v", err)
-	}
-
-	key, err := fhipe.DeriveKey(y, masterSecKey)
-	if err != nil {
-		t.Fatalf("Error during key derivation: %v", err)
-	}
-
+	// sample a vector that will be encrypted
+	sampler := sample.NewUniformRange(new(big.Int).Add(new(big.Int).Neg(bound), big.NewInt(1)), bound)
 	x, err := data.NewRandomVector(l, sampler)
 	if err != nil {
-		t.Fatalf("Error during random generation: %v", err)
+		t.Fatalf("Error during random vector generation: %v", err)
 	}
 
-	// simulate the instantiation of encryptor (which should be given masterPubKey)
+	// simulate the instantiation of an encryptor (which should know the master key)
 	encryptor := fullysec.NewFHIPEFromParams(fhipe.Params)
+	// encrypt the vector
 	ciphertext, err := encryptor.Encrypt(x, masterSecKey)
 	if err != nil {
 		t.Fatalf("Error during encryption: %v", err)
 	}
 
+	// sample a inner product vector
+	y, err := data.NewRandomVector(l, sampler)
+	if err != nil {
+		t.Fatalf("Error during random vecotr generation: %v", err)
+	}
+
+	// derive a functional key for vector y
+	key, err := fhipe.DeriveKey(y, masterSecKey)
+	if err != nil {
+		t.Fatalf("Error during key derivation: %v", err)
+	}
+
+	// simulate a decryptor
 	decryptor := fullysec.NewFHIPEFromParams(fhipe.Params)
+	// decryptor decrypts the inner-product without knowing
+	// vectors x and y
 	xy, err := decryptor.Decrypt(ciphertext, key)
 	if err != nil {
 		t.Fatalf("Error during decryption: %v", err)
 	}
 
+	// check the correctness of the result
 	xyCheck, err := x.Dot(y)
 	if err != nil {
 		t.Fatalf("Error during inner product calculation")


### PR DESCRIPTION
This PR implements an inner product functional encryption scheme that enables to hide the inner product function. It is based on the paper by Kim, Lewi, Mandal, Montgomery, Roy, Wu: [Function-Hiding Inner Product Encryption is Practical](https://eprint.iacr.org/2016/440.pdf)).
The scheme involves a computation of an inverse of a matrix. To achieve a fast computation of the inverse the Gaussian elimination is used. The latter primitive was implemented for the ABE schemes and is now moved in `data/matrix.go` file to be used by both schemes.