### PR TITLE
Function Hiding Multi-Input Inner Product Encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,17 +47,19 @@ We organized implementations in two categories based on their security assumptio
 
 * Schemes with **selective security under chosen-plaintext 
 attacks** (s-IND-CPA security):
-    * Scheme by _Abdalla et. al._ ([paper](https://eprint.iacr.org/2015/017.pdf)). The scheme can be instantiated from DDH (`simple.DDH`), LWE (`simple.LWE`)  primitives.
+    * Scheme by _Abdalla, Bourse, De Caro, Pointcheval_ ([paper](https://eprint.iacr.org/2015/017.pdf)). The scheme can be instantiated from DDH (`simple.DDH`), LWE (`simple.LWE`) primitives.
     * Experimental Ring-LWE scheme whose security will be argued in a future paper (`simple.RingLWE`)
-    * Multi-input scheme based on paper by _Abdalla et.al_ ([paper](https://eprint.iacr.org/2017/972.pdf)) and instantiated from the scheme in the first point (`simple.DDHMulti`).
+    * Multi-input scheme based on paper by _Abdalla, Catalano, Fiore, Gay, Ursu_ ([paper](https://eprint.iacr.org/2017/972.pdf)) and instantiated from the scheme in the first point (`simple.DDHMulti`).
 
 * Schemes with **adaptive security under chosen-plaintext attacks** (IND-CPA
 security):
     * Scheme based on paper by _Agrawal, Libert and Stehlé_ ([paper](https://eprint.iacr.org/2015/608.pdf)). It can be instantiated from Damgard DDH (`fullysec.Damgard` - similar to `simple.DDH`, but uses one more group element to achieve full security, similar to how Damgård's encryption scheme is obtained from ElGamal scheme ([paper](https://link.springer.com/chapter/10.1007/3-540-46766-1_36)), LWE (`fullysec.LWE`) and Paillier (`fullysec.Paillier`) primitives.
-    * Multi-input scheme based on paper by _Abdalla et.al_ ([paper](https://eprint.iacr.org/2017/972.pdf)) and instantiated from the scheme in the first point (`fullysec.DamgardMulti`).
+    * Multi-input scheme based on paper by _Abdalla, Catalano, Fiore, Gay, Ursu_ ([paper](https://eprint.iacr.org/2017/972.pdf)) and instantiated from the scheme in the first point (`fullysec.DamgardMulti`).
     * Decentralized scheme based on paper by _Chotard, Dufour Sans, Gay, Phan and Pointcheval_ ([paper](https://eprint.iacr.org/2017/989.pdf)). This scheme does not require a trusted party to generate keys. It is built on pairings (`fullysec.DMCFEClient`).
     * Decentralized scheme based on paper by _Abdalla, Benhamouda, Kohlweiss, Waldner_  ([paper](https://eprint.iacr.org/2019/020.pdf)). Similarly as above this scheme this scheme does not require a trusted party to generate keys and is based on a general 
 procedure for decentralization of an inner product scheme, in particular the decentralization of a Damgard DDH scheme (`fullysec.DamgardDecMultiClient`).
+    * Function hiding multi-input scheme based on paper by _Datta, Okamoto, Tomida_ ([paper](https://eprint.iacr.org/2018/061.pdf)). This scheme allows clients to encrypt vectors and derive 
+functional key that allows a decrytor to decrypt an inner product without revealing the ciphertext or the function (`fullysec.FHMultiIPE`).
 * Schemes with **simulation based security** (SIM-Security for IPE):
     * Function hiding inner product scheme by _Kim, Lewi, Mandal, Montgomery, Roy, Wu_ ([paper](https://eprint.iacr.org/2016/440.pdf)). The scheme allows the decryptor to
 decrypt the inner product of x and y without reveling (ciphertext) x or (function) y (`fullysec.fhipe`).

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ security):
 procedure for decentralization of an inner product scheme, in particular the decentralization of a Damgard DDH scheme (`fullysec.DamgardDecMultiClient`).
     * Function hiding multi-input scheme based on paper by _Datta, Okamoto, Tomida_ ([paper](https://eprint.iacr.org/2018/061.pdf)). This scheme allows clients to encrypt vectors and derive 
 functional key that allows a decrytor to decrypt an inner product without revealing the ciphertext or the function (`fullysec.FHMultiIPE`).
+
 * Schemes with **simulation based security** (SIM-Security for IPE):
     * Function hiding inner product scheme by _Kim, Lewi, Mandal, Montgomery, Roy, Wu_ ([paper](https://eprint.iacr.org/2016/440.pdf)). The scheme allows the decryptor to
 decrypt the inner product of x and y without reveling (ciphertext) x or (function) y (`fullysec.fhipe`).

--- a/data/matrix.go
+++ b/data/matrix.go
@@ -424,7 +424,7 @@ func (m Matrix) MulG1() MatrixG1 {
 }
 
 // MulG2 calculates m * [bn256.G1] and returns the
-// result in a new MatrixG1 instance.
+// result in a new MatrixG2 instance.
 func (m Matrix) MulG2() MatrixG2 {
 	prod := make(MatrixG2, len(m))
 	for i := range prod {

--- a/data/matrix.go
+++ b/data/matrix.go
@@ -423,6 +423,17 @@ func (m Matrix) MulG1() MatrixG1 {
 	return prod
 }
 
+// MulG2 calculates m * [bn256.G1] and returns the
+// result in a new MatrixG1 instance.
+func (m Matrix) MulG2() MatrixG2 {
+	prod := make(MatrixG2, len(m))
+	for i := range prod {
+		prod[i] = m[i].MulG2()
+	}
+
+	return prod
+}
+
 // MatMulMatG1 multiplies m and other in the sense that
 // if other is t * [bn256.G1] for some matrix t, then the
 // function returns m * t * [bn256.G1] where m * t is a

--- a/innerprod/fullysec/fh_multi_ipe.go
+++ b/innerprod/fullysec/fh_multi_ipe.go
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2018 XLAB d.o.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fullysec
+
+import (
+	"math/big"
+
+	"github.com/fentec-project/bn256"
+	"github.com/fentec-project/gofe/data"
+	"github.com/fentec-project/gofe/sample"
+)
+
+// L (int): The length of vectors to be encrypted.
+// BoundX (int): The value by which coordinates of encrypted vectors x are bounded.
+// BoundY (int): The value by which coordinates of inner product vectors y are bounded.
+type FHIPEParams struct {
+	L      int
+	BoundX *big.Int
+	BoundY *big.Int
+}
+
+// FHIPE represents a Function Hiding Inner Product Encryption scheme
+// based on the paper by Kim, Lewi, Mandal, Montgomery, Roy, Wu:
+// "Function-Hiding Inner Product Encryption is Practical".
+// It allows to encrypt a vector x and derive a secret key based
+// on an inner product vector y so that a deryptor can decrypt the
+// inner product <x,y> without revealing x or y.
+// The struct contains the shared choice for parameters on which
+// the functionality of the scheme depend.
+type FHMultiIPE struct {
+	NumClients int
+	VecLen     int
+	SecLevel   int
+}
+
+type FHMultiIPEPubKey struct {
+	GTMu *bn256.GT
+}
+
+type FHMultiIPESecKey struct {
+	BHat     []data.MatrixG1
+	BStarHat []data.MatrixG2
+}
+
+func NewFHMultiIPE(numClients, vecLen, secLevel int) *FHMultiIPE {
+	return &FHMultiIPE{NumClients: numClients, VecLen: vecLen, SecLevel: secLevel}
+}
+
+func (f FHMultiIPE) GenerateKeys() (*FHMultiIPESecKey, *FHMultiIPEPubKey, error) {
+	sampler := sample.NewUniformRange(big.NewInt(1), bn256.Order)
+	mu, err := sampler.Sample()
+	if err != nil {
+		return nil, nil, err
+	}
+	gTMu := new(bn256.GT).ScalarBaseMult(mu)
+
+	B := make([]data.MatrixG1, f.NumClients)
+	BStar := make([]data.MatrixG2, f.NumClients)
+	for i := 0; i < f.NumClients; i++ {
+		B[i], BStar[i], err = randomOB(2*f.VecLen+2*f.SecLevel+1, mu)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	BHat := make([]data.MatrixG1, f.NumClients)
+	BStarHat := make([]data.MatrixG2, f.NumClients)
+	for i := 0; i < f.NumClients; i++ {
+		BHat[i] = make(data.MatrixG1, f.VecLen+f.SecLevel)
+		BStarHat[i] = make(data.MatrixG2, f.VecLen+f.SecLevel)
+		for j := 0; j < f.VecLen+f.SecLevel; j++ {
+			if j < f.VecLen {
+				BHat[i][j] = B[i][j]
+				BStarHat[i][j] = BStar[i][j]
+			} else {
+				BHat[i][j] = B[i][j+f.VecLen+f.SecLevel]
+				BStarHat[i][j] = BStar[i][j+f.VecLen]
+			}
+		}
+	}
+
+	return &FHMultiIPESecKey{BHat: BHat, BStarHat: BStarHat},
+		&FHMultiIPEPubKey{GTMu: gTMu}, nil
+}
+
+func randomOB(l int, mu *big.Int) (data.MatrixG1, data.MatrixG2, error) {
+	sampler := sample.NewUniform(bn256.Order)
+	BMat, err := data.NewRandomMatrix(l, l, sampler)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	BStarMat, _, err := BMat.InverseModGauss(bn256.Order)
+	if err != nil {
+		return nil, nil, err
+	}
+	BStarMat = BStarMat.Transpose()
+	BStarMat = BStarMat.MulScalar(mu)
+
+	//B := make(data.MatrixG1, l)
+	//zeroVec := data.NewConstantVector(l, big.NewInt(0))
+	//for i:=0; i<l; i++ {
+	//	Bi := zeroVec.MulG1()
+	//	for j := 0; j < l; j++ {
+	//		Ai := zeroVec
+	//	}
+	//}
+
+	B := BMat.MulG1()
+	BStar := BStarMat.MulG2()
+
+	return B, BStar, nil
+}

--- a/innerprod/fullysec/fh_multi_ipe.go
+++ b/innerprod/fullysec/fh_multi_ipe.go
@@ -31,8 +31,8 @@ import (
 // so called k-Lin assumption, where k is the specified SecLevel.
 // NumClients (int): The number of clients participating
 // VecLen (int): The length of vectors that clients encrypt.
-// BoundX (int): The value by which coordinates of encrypted vectors x are bounded.
-// BoundY (int): The value by which coordinates of inner product vectors y are bounded.
+// BoundX (int): The value by which the coordinates of encrypted vectors are bounded.
+// BoundY (int): The value by which the coordinates of inner product vectors are bounded.
 type FHMultiIPEParams struct {
 	SecLevel   int
 	NumClients int
@@ -45,7 +45,7 @@ type FHMultiIPEParams struct {
 // Encryption scheme based on the paper by P. Datta, T. Okamoto, and
 // J. Tomida:
 // "Full-Hiding (Unbounded) Multi-Input Inner Product Functional Encryption
-// from the𝒌-Linear Assumption".
+// from the 𝒌-Linear Assumption".
 // It allows clients to encrypt vectors {x_1,...,x_m} and derive a secret key
 // based on an inner product vectors {y_1,...,y_m} so that a decryptor can
 // decrypt the sum of inner products <x_1,y_2> + ... + <x_m, y_m> without
@@ -55,8 +55,8 @@ type FHMultiIPEParams struct {
 // of elliptic curve elements g_1^B, g_2^BStar. This replaces elliptic curves
 // operations with matrix multiplication.
 //
-// This struct contains the shared choice for
-// parameters on which the functionality of the scheme depend.
+// This struct contains the shared choice for parameters on which the
+// functionality of the scheme depend.
 type FHMultiIPE struct {
 	Params *FHMultiIPEParams
 }

--- a/innerprod/fullysec/fh_multi_ipe.go
+++ b/innerprod/fullysec/fh_multi_ipe.go
@@ -48,7 +48,7 @@ type FHMultiIPEParams struct {
 // from the 𝒌-Linear Assumption".
 // It allows clients to encrypt vectors {x_1,...,x_m} and derive a secret key
 // based on an inner product vectors {y_1,...,y_m} so that a decryptor can
-// decrypt the sum of inner products <x_1,y_2> + ... + <x_m, y_m> without
+// decrypt the sum of inner products <x_1,y_1> + ... + <x_m, y_m> without
 // revealing vectors x_i or y_i. The scheme is slightly modified from the
 // original one to achieve a better performance. The difference is in
 // storing the secret master key as matrices B, BStar, instead of matrices
@@ -152,7 +152,7 @@ func randomOB(l int, mu *big.Int) (data.Matrix, data.Matrix, error) {
 // DeriveKey takes a matrix y whose rows are input vector y_1,...,y_m and
 // master secret key, and returns the functional encryption key. That is
 // a key that for encrypted x_1,...,x_m allows to calculate the sum of
-// inner products <x_1,y_2> + ... + <x_m, y_m>. In case the key could not
+// inner products <x_1,y_1> + ... + <x_m, y_m>. In case the key could not
 // be derived, it returns an error.
 func (f FHMultiIPE) DeriveKey(y data.Matrix, secKey *FHMultiIPESecKey) (data.MatrixG2, error) {
 	sampler := sample.NewUniform(bn256.Order)
@@ -219,7 +219,7 @@ func (f FHMultiIPE) Encrypt(x data.Vector, partSecKey data.Matrix) (data.VectorG
 
 // Decrypt accepts the ciphertext as a matrix whose rows are encryptions of vectors
 // x_1,...,x_m and a functional encryption key corresponding to vectors y_1,...,y_m.
-// It returns the sum of inner products <x_1,y_2> + ... + <x_m, y_m>. If decryption
+// It returns the sum of inner products <x_1,y_1> + ... + <x_m, y_m>. If decryption
 // failed, an error is returned.
 func (f *FHMultiIPE) Decrypt(cipher data.MatrixG1, key data.MatrixG2, pubKey *bn256.GT) (*big.Int, error) {
 	sum := new(bn256.GT).ScalarBaseMult(big.NewInt(0))

--- a/innerprod/fullysec/fh_multi_ipe_test.go
+++ b/innerprod/fullysec/fh_multi_ipe_test.go
@@ -1,0 +1,1 @@
+package fullysec

--- a/innerprod/fullysec/fh_multi_ipe_test.go
+++ b/innerprod/fullysec/fh_multi_ipe_test.go
@@ -1,1 +1,100 @@
-package fullysec
+/*
+ * Copyright (c) 2018 XLAB d.o.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fullysec_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/fentec-project/gofe/data"
+	"github.com/fentec-project/gofe/innerprod/fullysec"
+	"github.com/fentec-project/gofe/sample"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFH_Multi_IPE(t *testing.T) {
+	// choose the parameters for the encryption and build the scheme
+	secLevel := 2
+	vecLen := 1
+	numClient := 100
+	bound := big.NewInt(10)
+
+
+	fhmulti := fullysec.NewFHMultiIPE(numClient, vecLen, secLevel, bound, bound)
+
+	// generate master key
+	masterSecKey, pubKey, err := fhmulti.GenerateKeys()
+	if err != nil {
+		t.Fatalf("Error during master key generation: %v", err)
+	}
+
+	// sample a vector that will be encrypted
+	sampler := sample.NewUniformRange(new(big.Int).Add(new(big.Int).Neg(bound), big.NewInt(1)), bound)
+	x := make(data.Matrix, numClient)
+	for i := 0; i < numClient; i++ {
+		x[i], err = data.NewRandomVector(vecLen, sampler)
+		if err != nil {
+			t.Fatalf("Error during random vector generation: %v", err)
+		}
+	}
+
+
+	//// simulate the instantiation of an encryptor (which should know the master key)
+	//encryptor := fullysec.NewFHIPEFromParams(fhipe.Params)
+	//// encrypt the vector
+	//ciphertext, err := encryptor.Encrypt(x, masterSecKey)
+	//if err != nil {
+	//	t.Fatalf("Error during encryption: %v", err)
+	//}
+
+	cipher := make(data.MatrixG1, numClient)
+	for i := 0; i < numClient; i++ {
+		cipher[i], err = fhmulti.Encrypt(x[i], masterSecKey.BHat[i])
+	}
+
+
+	// sample a inner product vector
+	y := make(data.Matrix, numClient)
+	for i := 0; i < numClient; i++ {
+		y[i], err = data.NewRandomVector(vecLen, sampler)
+		if err != nil {
+			t.Fatalf("Error during random vector generation: %v", err)
+		}
+	}
+
+	// derive a functional key for vector y
+	key, err := fhmulti.DeriveKey(y, masterSecKey)
+	if err != nil {
+		t.Fatalf("Error during key derivation: %v", err)
+	}
+
+	// simulate a decryptor
+	//decryptor := fullysec.NewFHIPEFromParams(fhipe.Params)
+	// decryptor decrypts the inner-product without knowing
+	// vectors x and y
+	xy, err := fhmulti.Decrypt(cipher, key, pubKey)
+	if err != nil {
+		t.Fatalf("Error during decryption: %v", err)
+	}
+
+	// check the correctness of the result
+	xyCheck, err := x.Dot(y)
+	if err != nil {
+		t.Fatalf("Error during inner product calculation")
+	}
+	assert.Equal(t, xy.Cmp(xyCheck), 0, "obtained incorrect inner product")
+}

--- a/innerprod/fullysec/fh_multi_ipe_test.go
+++ b/innerprod/fullysec/fh_multi_ipe_test.go
@@ -27,13 +27,14 @@ import (
 )
 
 func TestFH_Multi_IPE(t *testing.T) {
-	// choose the parameters for the encryption and build the scheme
+	// choose the parameters for the scheme
 	secLevel := 2
 	vecLen := 10
 	numClient := 5
 	bound := big.NewInt(128)
 
-	fhmulti := fullysec.NewFHMultiIPE(numClient, vecLen, secLevel, bound, bound)
+	// build the scheme
+	fhmulti := fullysec.NewFHMultiIPE(secLevel, numClient, vecLen, bound, bound)
 
 	// generate master secret key and public key
 	masterSecKey, pubKey, err := fhmulti.GenerateKeys()

--- a/innerprod/fullysec/fhipe.go
+++ b/innerprod/fullysec/fhipe.go
@@ -28,6 +28,7 @@ import (
 	"github.com/fentec-project/gofe/sample"
 )
 
+// FHIPEParams holds common parameters used in the scheme. These are:
 // L (int): The length of vectors to be encrypted.
 // BoundX (int): The value by which coordinates of encrypted vectors x are bounded.
 // BoundY (int): The value by which coordinates of inner product vectors y are bounded.

--- a/innerprod/fullysec/fhipe_test.go
+++ b/innerprod/fullysec/fhipe_test.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/fentec-project/gofe/data"
 	"github.com/fentec-project/gofe/innerprod/fullysec"
-	"github.com/stretchr/testify/assert"
 	"github.com/fentec-project/gofe/sample"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFHIPE(t *testing.T) {


### PR DESCRIPTION
This PR implements a Function Hiding Multi-Input Inner Product Encryption scheme based on the paper by P. Datta, T. Okamoto, and J. Tomida: [Full-Hiding  (Unbounded) Multi-Input Inner Product Functional Encryptionfrom the 𝒌-Linear Assumption](https://eprint.iacr.org/2018/061.pdf).
It allows clients to encrypt vectors {x_1,...,x_m} and derive a secret key based on an inner product vectors {y_1,...,y_m} so that a decryptor can decrypt the sum of inner products <x_1,y_2> + ... + <x_m, y_m> without revealing vectors x_i or y_i. The implemented scheme is slightly modified from the original one to achieve a better performance. The difference is in storing the secret master key as matrices B, BStar, instead of matrices of elliptic curve elements g_1^B, g_2^BStar. This replaces elliptic curves operations with matrix multiplication.