### PR TITLE
Public key quadratic scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ bilinear pairings, and offers adaptive security under chosen-plaintext
 attacks (IND-CPA security). You will need `SGP` scheme from package `quadratic`.
 * Second is an efficient pubic key FE by _Romain Gay_ ([paper](https://eprint.iacr.org/2020/093.pdf))
 that is based on the underlying partially function hiding inner product scheme and offers semi-adaptive
-simulation based security.
+simulation based security. You will need `quad` scheme from package `quadratic`.
 
 #### Schemes with attribute based encryption (ABE)
 Schemes are organized under package `abe`.

--- a/README.md
+++ b/README.md
@@ -67,21 +67,24 @@ procedure for decentralization of an inner product scheme, in particular the dec
 functional key that allows a decrytor to decrypt an inner product without revealing the ciphertext or the function (`fullysec.FHMultiIPE`).
     * Function hiding inner product scheme by _Kim, Lewi, Mandal, Montgomery, Roy, Wu_ ([paper](https://eprint.iacr.org/2016/440.pdf)). The scheme allows the decryptor to
 decrypt the inner product of x and y without reveling (ciphertext) x or (function) y (`fullysec.fhipe`).
+    * Partially function hiding inner product scheme by _Romain Gay_ ([paper](https://eprint.iacr.org/2020/093.pdf)). This scheme
+ is a public key inner product scheme that decrypt the inner product of x and y without reveling (ciphertext) x or (function) y. This is
+ achieved by limiting the space of vectors that can be encrypted with a public key (`fullysec.partFHIPE`).
 
 #### Quadratic polynomial schemes
-You will need `SGP` scheme from package `quadratic`. 
-
-It contains an
-implementation of an efficient FE scheme for **quadratic multi-variate
-polynomials** by _Dufour Sans, Gay_ and _Pointcheval_ 
+There are two implemented FE schemes for **quadratic multi-variate polynomials**:
+* First is an efficient symmetric FE scheme by _Dufour Sans, Gay_ and _Pointcheval_ 
 ([paper](https://eprint.iacr.org/2018/206.pdf)) which is based on
 bilinear pairings, and offers adaptive security under chosen-plaintext
-attacks (IND-CPA security).
+attacks (IND-CPA security). You will need `SGP` scheme from package `quadratic`.
+* Second is an efficient pubic key FE by _Romain Gay_ ([paper](https://eprint.iacr.org/2020/093.pdf))
+that is based on the underlying partially function hiding inner product scheme and offers semi-adaptive
+simulation based security.
 
 #### Schemes with attribute based encryption (ABE)
 Schemes are organized under package `abe`.
 
-It contains two ABE schemes:
+It contains three ABE schemes:
 * A ciphertext policy (CP) ABE scheme named FAME by _Agrawal, Chase_ ([paper](https://eprint.iacr.org/2017/807.pdf)) allowing encrypting a
 message based on a boolean expression defining a policy which attributes are needed for the decryption. It is implemented in `abe.fame`.
 * A key policy (KP) ABE scheme by _Goyal, Pandey, Sahai, Waters_ ([paper](https://eprint.iacr.org/2006/309.pdf)) allowing a distribution of

--- a/data/matrix.go
+++ b/data/matrix.go
@@ -778,7 +778,7 @@ func (m Matrix) ToVec() Vector {
 // with columns from both matrices.
 func (m Matrix) JoinCols(other Matrix) (Matrix, error) {
 	if m.Rows() != other.Rows() {
-		return nil, fmt.Errorf("dimensions don't fit")
+		return nil, fmt.Errorf("dimensions do not fit")
 	}
 
 	res := make(Matrix, m.Rows())
@@ -800,7 +800,7 @@ func (m Matrix) JoinCols(other Matrix) (Matrix, error) {
 // with rows from both matrices.
 func (m Matrix) JoinRows(other Matrix) (Matrix, error) {
 	if m.Cols() != other.Cols() {
-		return nil, fmt.Errorf("dimensions don't fit")
+		return nil, fmt.Errorf("dimensions do not fit")
 	}
 
 	res := make(Matrix, m.Rows()+other.Rows())
@@ -818,8 +818,8 @@ func (m Matrix) JoinRows(other Matrix) (Matrix, error) {
 	return res, nil
 }
 
-// Id returns the identity matrix with given dimensions.
-func Id(rows, cols int) Matrix {
+// Identity returns the identity matrix with given dimensions.
+func Identity(rows, cols int) Matrix {
 	res := NewConstantMatrix(rows, cols, big.NewInt(0))
 	for i := 0; i < rows && i < cols; i++ {
 		res[i][i].SetInt64(1)

--- a/data/matrix.go
+++ b/data/matrix.go
@@ -736,3 +736,30 @@ func GaussianEliminationSolver(mat Matrix, v Vector, p *big.Int) (Vector, error)
 
 	return ret, nil
 }
+
+// Tensor creates a tensor product of matrices m and other.
+// The result is returned in a new Matrix.
+func (m Matrix) Tensor(other Matrix) Matrix {
+	prod := make(Matrix, m.Rows() * other.Rows())
+	for i := 0; i < prod.Rows(); i++ {
+		prod[i] = make(Vector, other.Cols()*other.Cols())
+		for j := 0; j < len(prod[i]); j++ {
+			prod[i][j] = new(big.Int).Mul(m[i / other.Rows()][j / other.Cols()], other[i % other.Rows()][j % other.Cols()])
+		}
+	}
+
+	return prod
+}
+
+// ToVec creates a vector whose entries are entries of m
+// ordered as m_11, m_12,..., m_21, m_22,..., m_kl.
+func (m Matrix) ToVec() Vector {
+	res := make(Vector, m.Rows() * m.Cols())
+	for i := 0; i < len(res); i++ {
+		for j := 0; j < len(res); j++ {
+			res[len(m) * i + j] = new(big.Int).Set(m[i][j])
+		}
+	}
+
+	return res
+}

--- a/data/matrix.go
+++ b/data/matrix.go
@@ -99,6 +99,16 @@ func NewConstantMatrix(rows, cols int, c *big.Int) Matrix {
 	return mat
 }
 
+// Copy creates a new Matrix with the same values.
+func (m Matrix) Copy() Matrix {
+	mat := make(Matrix, m.Rows())
+	for i := 0; i < m.Rows(); i++ {
+		mat[i] = m[i].Copy()
+	}
+
+	return mat
+}
+
 // Rows returns the number of rows of matrix m.
 func (m Matrix) Rows() int {
 	return len(m)
@@ -740,11 +750,11 @@ func GaussianEliminationSolver(mat Matrix, v Vector, p *big.Int) (Vector, error)
 // Tensor creates a tensor product of matrices m and other.
 // The result is returned in a new Matrix.
 func (m Matrix) Tensor(other Matrix) Matrix {
-	prod := make(Matrix, m.Rows() * other.Rows())
+	prod := make(Matrix, m.Rows()*other.Rows())
 	for i := 0; i < prod.Rows(); i++ {
 		prod[i] = make(Vector, m.Cols()*other.Cols())
 		for j := 0; j < len(prod[i]); j++ {
-			prod[i][j] = new(big.Int).Mul(m[i / other.Rows()][j / other.Cols()], other[i % other.Rows()][j % other.Cols()])
+			prod[i][j] = new(big.Int).Mul(m[i/other.Rows()][j/other.Cols()], other[i%other.Rows()][j%other.Cols()])
 		}
 	}
 
@@ -754,10 +764,10 @@ func (m Matrix) Tensor(other Matrix) Matrix {
 // ToVec creates a vector whose entries are entries of m
 // ordered as m_11, m_12,..., m_21, m_22,..., m_kl.
 func (m Matrix) ToVec() Vector {
-	res := make(Vector, m.Rows() * m.Cols())
+	res := make(Vector, m.Rows()*m.Cols())
 	for i := 0; i < m.Rows(); i++ {
 		for j := 0; j < m.Cols(); j++ {
-			res[m.Cols() * i + j] = new(big.Int).Set(m[i][j])
+			res[m.Cols()*i+j] = new(big.Int).Set(m[i][j])
 		}
 	}
 
@@ -773,12 +783,12 @@ func (m Matrix) JoinCols(other Matrix) (Matrix, error) {
 
 	res := make(Matrix, m.Rows())
 	for i := 0; i < m.Rows(); i++ {
-		res[i] = make(Vector, m.Cols() + other.Cols())
-		for j := 0; j < m.Cols() + other.Cols(); j++ {
+		res[i] = make(Vector, m.Cols()+other.Cols())
+		for j := 0; j < m.Cols()+other.Cols(); j++ {
 			if j < m.Cols() {
 				res[i][j] = new(big.Int).Set(m[i][j])
 			} else {
-				res[i][j] = new(big.Int).Set(other[i][j - m.Cols()])
+				res[i][j] = new(big.Int).Set(other[i][j-m.Cols()])
 			}
 		}
 	}
@@ -793,14 +803,14 @@ func (m Matrix) JoinRows(other Matrix) (Matrix, error) {
 		return nil, fmt.Errorf("dimensions don't fit")
 	}
 
-	res := make(Matrix, m.Rows() + other.Rows())
+	res := make(Matrix, m.Rows()+other.Rows())
 	for i := 0; i < res.Rows(); i++ {
 		res[i] = make(Vector, m.Cols())
 		for j := 0; j < m.Cols(); j++ {
 			if i < m.Rows() {
 				res[i][j] = new(big.Int).Set(m[i][j])
 			} else {
-				res[i][j] = new(big.Int).Set(other[i - m.Rows()][j])
+				res[i][j] = new(big.Int).Set(other[i-m.Rows()][j])
 			}
 		}
 	}

--- a/data/matrix_test.go
+++ b/data/matrix_test.go
@@ -289,5 +289,5 @@ func TestMatrix_Tensor(t *testing.T) {
 	}
 	prod := m1.Tensor(m2)
 
-	assert.Equal(t, prodExpected, prod, "product of matrices does not work correctly")
+	assert.Equal(t, prodExpected, prod, "tensor product of matrices does not work correctly")
 }

--- a/data/matrix_test.go
+++ b/data/matrix_test.go
@@ -273,3 +273,21 @@ func TestMatrix_GaussianElimintaion(t *testing.T) {
 	_, err = GaussianEliminationSolver(matWrong, v, p)
 	assert.Error(t, err)
 }
+
+func TestMatrix_Tensor(t *testing.T) {
+	m1 := Matrix{
+		Vector{big.NewInt(1), big.NewInt(2)},
+		Vector{big.NewInt(3), big.NewInt(4)},
+	}
+	m2 := Matrix{
+		Vector{big.NewInt(1), big.NewInt(2)},
+	}
+
+	prodExpected := Matrix{
+		Vector{big.NewInt(1), big.NewInt(2), big.NewInt(2), big.NewInt(4)},
+		Vector{big.NewInt(3), big.NewInt(6), big.NewInt(4), big.NewInt(8)},
+	}
+	prod := m1.Tensor(m2)
+
+	assert.Equal(t, prodExpected, prod, "product of matrices does not work correctly")
+}

--- a/data/vector.go
+++ b/data/vector.go
@@ -169,6 +169,17 @@ func (v Vector) Apply(f func(*big.Int) *big.Int) Vector {
 	return res
 }
 
+// Sub returns -v for given vector v.
+// The result is returned in a new Vector.
+func (v Vector) Neg() Vector {
+	neg := make([]*big.Int, len(v))
+	for i, c := range v {
+		neg[i] = new(big.Int).Neg(c)
+	}
+
+	return neg
+}
+
 // Add adds vectors v and other.
 // The result is returned in a new Vector.
 func (v Vector) Add(other Vector) Vector {
@@ -250,7 +261,11 @@ func (v Vector) MulAsPolyInRing(other Vector) (Vector, error) {
 func (v Vector) MulG1() VectorG1 {
 	prod := make(VectorG1, len(v))
 	for i := range prod {
-		prod[i] = new(bn256.G1).ScalarBaseMult(v[i])
+		vi := new(big.Int).Abs(v[i])
+		prod[i] = new(bn256.G1).ScalarBaseMult(vi)
+		if v[i].Sign() == -1 {
+			prod[i].Neg(prod[i])
+		}
 	}
 
 	return prod
@@ -282,7 +297,11 @@ func (v Vector) MulVecG1(g1 VectorG1) VectorG1 {
 func (v Vector) MulG2() VectorG2 {
 	prod := make(VectorG2, len(v))
 	for i := range prod {
-		prod[i] = new(bn256.G2).ScalarBaseMult(v[i])
+		vi := new(big.Int).Abs(v[i])
+		prod[i] = new(bn256.G2).ScalarBaseMult(vi)
+		if v[i].Sign() == -1 {
+			prod[i].Neg(prod[i])
+		}
 	}
 
 	return prod
@@ -320,9 +339,9 @@ func (v Vector) String() string {
 // Tensor creates a tensor product of vectors v and other.
 // The result is returned in a new Vector.
 func (v Vector) Tensor(other Vector) Vector {
-	prod := make(Vector, len(v) * len(other))
+	prod := make(Vector, len(v)*len(other))
 	for i := 0; i < len(prod); i++ {
-		prod[i] = new(big.Int).Mul(v[i / len(other)], other[i % len(other)])
+		prod[i] = new(big.Int).Mul(v[i/len(other)], other[i%len(other)])
 	}
 
 	return prod

--- a/data/vector.go
+++ b/data/vector.go
@@ -316,3 +316,14 @@ func (v Vector) String() string {
 	}
 	return vStr
 }
+
+// Tensor creates a tensor product of vectors v and other.
+// The result is returned in a new Vector.
+func (v Vector) Tensor(other Vector) Vector {
+	prod := make(Vector, len(v) * len(other))
+	for i := 0; i < len(prod); i++ {
+		prod[i] = new(big.Int).Mul(v[i / len(other)], other[i % len(other)])
+	}
+
+	return prod
+}

--- a/data/vector.go
+++ b/data/vector.go
@@ -169,7 +169,7 @@ func (v Vector) Apply(f func(*big.Int) *big.Int) Vector {
 	return res
 }
 
-// Sub returns -v for given vector v.
+// Neg returns -v for given vector v.
 // The result is returned in a new Vector.
 func (v Vector) Neg() Vector {
 	neg := make([]*big.Int, len(v))

--- a/data/vector_test.go
+++ b/data/vector_test.go
@@ -76,3 +76,14 @@ func TestVector_MulAsPolyInRing(t *testing.T) {
 
 	assert.Equal(t, prod, Vector{big.NewInt(-2), big.NewInt(2), big.NewInt(5)})
 }
+
+func TestVecor_Tensor(t *testing.T) {
+	v1 := Vector{big.NewInt(1), big.NewInt(2)}
+
+	v2 := Vector{big.NewInt(1), big.NewInt(2)}
+
+	prodExpected := Vector{big.NewInt(1), big.NewInt(2), big.NewInt(2), big.NewInt(4)}
+	prod := v1.Tensor(v2)
+
+	assert.Equal(t, prodExpected, prod, "product of matrices does not work correctly")
+}

--- a/data/vector_test.go
+++ b/data/vector_test.go
@@ -85,5 +85,5 @@ func TestVecor_Tensor(t *testing.T) {
 	prodExpected := Vector{big.NewInt(1), big.NewInt(2), big.NewInt(2), big.NewInt(4)}
 	prod := v1.Tensor(v2)
 
-	assert.Equal(t, prodExpected, prod, "product of matrices does not work correctly")
+	assert.Equal(t, prodExpected, prod, "tensor product of vectors does not work correctly")
 }

--- a/innerprod/fullysec/damgard.go
+++ b/innerprod/fullysec/damgard.go
@@ -221,7 +221,6 @@ func (d *Damgard) GenerateMasterKeys() (*DamgardSecKey, data.Vector, error) {
 		y2 := new(big.Int).Exp(d.Params.H, t, d.Params.P)
 
 		masterPubKey[i] = new(big.Int).Mod(new(big.Int).Mul(y1, y2), d.Params.P)
-
 	}
 
 	return &DamgardSecKey{S: mskS, T: mskT}, masterPubKey, nil

--- a/innerprod/fullysec/dmcfe.go
+++ b/innerprod/fullysec/dmcfe.go
@@ -92,7 +92,6 @@ func (c *DMCFEClient) SetShare(pubKeys []*bn256.G1) error {
 			if err != nil {
 				return err
 			}
-
 		}
 		c.Share = c.Share.Mod(bn256.Order)
 	}
@@ -102,7 +101,6 @@ func (c *DMCFEClient) SetShare(pubKeys []*bn256.G1) error {
 
 // Encrypt encrypts number x under some label.
 func (c *DMCFEClient) Encrypt(x *big.Int, label string) (*bn256.G1, error) {
-
 	cipher := new(bn256.G1).ScalarBaseMult(big.NewInt(0))
 	for i := 0; i < 2; i++ {
 		hs, err := bn256.HashG1(strconv.Itoa(i) + " " + label)

--- a/innerprod/fullysec/fhipe.go
+++ b/innerprod/fullysec/fhipe.go
@@ -222,7 +222,6 @@ func (d *FHIPE) Decrypt(cipher *FHIPECipher, key *FHIPEDerivedKey) (*big.Int, er
 	for i := 0; i < d.Params.L; i++ {
 		pairedI := bn256.Pair(key.K2[i], cipher.C2[i])
 		d2 = new(bn256.GT).Add(pairedI, d2)
-
 	}
 
 	// calculate the upper bound of the result needed for the

--- a/innerprod/fullysec/lwe.go
+++ b/innerprod/fullysec/lwe.go
@@ -85,7 +85,6 @@ type LWE struct {
 // It returns an error in case public parameters of the scheme could
 // not be generated.
 func NewLWE(l, n int, boundX, boundY *big.Int) (*LWE, error) {
-
 	// K = 2 * l * boundX * boundY
 	K := new(big.Int).Mul(boundX, boundY)
 	K.Mul(K, big.NewInt(int64(l*2)))

--- a/innerprod/fullysec/part_fh_ipe.go
+++ b/innerprod/fullysec/part_fh_ipe.go
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2018 XLAB d.o.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fullysec
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/fentec-project/gofe/data"
+	"github.com/fentec-project/gofe/sample"
+	"github.com/fentec-project/bn256"
+	"github.com/fentec-project/gofe/internal/dlog"
+)
+
+// DamgardParams includes public parameters for the Damgard inner
+// product scheme.
+// L (int): The length of vectors to be encrypted.
+// Bound (int): The value by which coordinates of vectors x and y are bounded.
+// G (int): Generator of a cyclic group Z_P: G**(Q) = 1 (mod P).
+// H (int): Generator of a cyclic group Z_P: H**(Q) = 1 (mod P).
+// P (int): Modulus - we are operating in a cyclic group Z_P.
+// Q (int): Multiplicative order of G and H.
+type PartFHIPEParams struct {
+	L int
+	K int
+	Bound      *big.Int
+	p big.Int
+}
+
+// Damgard represents a scheme instantiated from the DDH assumption
+// based on DDH variant of:
+// Agrawal, Shweta, Libert, and Stehle:
+// "Fully secure functional encryption for inner products,
+// from standard assumptions".
+type PartFHIPE struct {
+	Params *PartFHIPEParams
+}
+
+// NewDamgard configures a new instance of the scheme.
+// It accepts the length of input vectors l, the bit length of the
+// modulus (we are operating in the Z_p group), and a bound by which
+// coordinates of input vectors are bounded.
+//
+// It returns an error in case the scheme could not be properly
+// configured, or if precondition l * bound² is >= order of the cyclic
+// group.
+func NewPartFHIPE(l, k int, bound *big.Int) *PartFHIPE {
+	return &PartFHIPE{
+		Params: &PartFHIPEParams{
+			L:     l,
+			K: k,
+			Bound: bound,
+		},
+	}
+}
+
+
+// NewDamgardFromParams takes configuration parameters of an existing
+// Damgard scheme instance, and reconstructs the scheme with same configuration
+// parameters. It returns a new Damgard instance.
+func NewPartFHIPEFromParams(params *PartFHIPEParams) *PartFHIPE {
+	return &PartFHIPE{
+		Params: params,
+	}
+}
+
+// DamgardSecKey is a secret key for Damgard scheme.
+type PartFHIPESecKey struct {
+	B data.VectorG2
+	V data.Matrix
+	U data.Matrix
+}
+
+// DamgardSecKey is a secret key for Damgard scheme.
+type PartFHIPEPubKey struct {
+	A data.VectorG1
+	Ua data.VectorG1
+	VtM data.MatrixG1
+	MG1 data.MatrixG1
+}
+
+// GenerateMasterKeys generates a master secret key and master
+// public key for the scheme. It returns an error in case master keys
+// could not be generated.
+func (d *PartFHIPE) GenerateKeys(M data.Matrix) (*PartFHIPEPubKey, *PartFHIPESecKey, error) {
+	if d.Params.L != M.Rows() || d.Params.K != M.Cols() {
+		return nil, nil, fmt.Errorf("dimensions of the given matrix do not match dimensions of the scheme")
+	}
+	sampler := sample.NewUniform(bn256.Order)
+	//sampler = sample.NewUniformRange(big.NewInt(0), big.NewInt(1))
+	//sampler2 := sample.NewUniformRange(big.NewInt(0), big.NewInt(1))
+
+
+	aVec := make(data.Vector, 2)
+	bVec := make(data.Vector, 2)
+
+	aVec[0] = big.NewInt(1)
+	bVec[0] = big.NewInt(1)
+
+	x, err := sampler.Sample()
+	if err != nil {
+		return nil, nil, err
+	}
+	aVec[1] = x
+
+	x, err = sampler.Sample()
+	if err != nil {
+		return nil, nil, err
+	}
+	bVec[1] = x
+
+	a := aVec.MulG1()
+	b := bVec.MulG2()
+
+	U, err := data.NewRandomMatrix(d.Params.L + 2, 2, sampler)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	V, err := data.NewRandomMatrix(d.Params.L, 2, sampler)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	UaVec, err := U.MulVec(aVec)
+	if err != nil {
+		return nil, nil, err
+	}
+	Ua := UaVec.MulG1()
+
+	VtMMat, err := V.Transpose().Mul(M)
+	if err != nil {
+		return nil, nil, err
+	}
+	VtM := VtMMat.MulG1()
+
+	MG1 := M.MulG1()
+
+	return &PartFHIPEPubKey{A: a, Ua: Ua, VtM: VtM, MG1: MG1},
+		   &PartFHIPESecKey{B: b, V: V, U: U},
+		   nil
+}
+
+// TODO: maybe optimize to b being vector
+// DeriveKey takes master secret key and input vector y, and returns the
+// functional encryption key. In case the key could not be derived, it
+// returns an error.
+func (d *PartFHIPE) DeriveKey(y data.Vector, secKey *PartFHIPESecKey) (data.VectorG2, error) {
+	if err := y.CheckBound(d.Params.Bound); err != nil {
+		return nil, err
+	}
+
+	sampler := sample.NewUniform(bn256.Order)
+	//sampler = sample.NewUniformRange(big.NewInt(0), big.NewInt(1))
+
+	s, err := sampler.Sample()
+	if err != nil {
+		return nil, err
+	}
+
+	//key2 := make(data.VectorG2, d.Params.L + 2)
+	bs := secKey.B.MulScalar(s)
+
+	Vbs, err := secKey.V.MatMulVecG2(bs)
+	if err != nil {
+		return nil, err
+	}
+	yG2 := y.MulG2()
+	YVbs := Vbs.Add(yG2)
+	key2 := append(bs, YVbs...)
+	//key2[:2] = bs
+	//key2[2:] = YVbs
+
+	key1, err := secKey.U.Transpose().MatMulVecG2(key2)
+	if err != nil {
+		return nil, err
+	}
+	key1 = key1.Neg()
+
+	//key := make(data.VectorG2, d.Params.L + 4)
+	//key[:2] = key1
+	//key[2:] = key2
+	key := append(key1, key2...)
+
+	return key, nil
+}
+
+
+
+
+// Encrypt encrypts input vector x with the provided master public key.
+// It returns a ciphertext vector. If encryption failed, error is returned.
+func (d *PartFHIPE) Encrypt(x data.Vector, pubKey *PartFHIPEPubKey) (data.VectorG1, error) {
+	// todo: different check
+	if err := x.CheckBound(d.Params.Bound); err != nil {
+		return nil, err
+	}
+
+	sampler := sample.NewUniform(bn256.Order)
+	//sampler = sample.NewUniformRange(big.NewInt(0), big.NewInt(1))
+
+	r, err := sampler.Sample()
+	if err != nil {
+		return nil, err
+	}
+
+	c := pubKey.A.MulScalar(r)
+	Uc := pubKey.Ua.MulScalar(r)
+
+	Mx := pubKey.MG1.MulVector(x)
+	VtMx := pubKey.VtM.MulVector(x)
+	VtMxNeg := VtMx.Neg()
+	cipher2 := append(VtMxNeg, Mx...)
+	cipher2add := cipher2.Add(Uc)
+
+	cipher := append(c, cipher2add...)
+
+	//fmt.Println(c, cipher2, cipher)
+
+	return cipher, nil
+}
+
+// Decrypt accepts the encrypted vector, functional encryption key, and
+// a plaintext vector y. It returns the inner product of x and y.
+// If decryption failed, error is returned.
+func (d *PartFHIPE) Decrypt(cipher data.VectorG1, key data.VectorG2) (*big.Int, error) {
+	dec := new(bn256.GT).ScalarBaseMult(big.NewInt(0))
+	fmt.Println(len(key), len(cipher), d.Params.L + 4)
+	for i := 0; i < d.Params.L + 4; i++ {
+		pairedI := bn256.Pair(cipher[i], key[i])
+		dec = new(bn256.GT).Add(pairedI, dec)
+	}
+
+	//bSquared := new(big.Int).Mul(d.Params.Bound, d.Params.Bound)
+	//bound := new(big.Int).Mul(big.NewInt(int64(d.Params.L)), bSquared)
+	calc := dlog.NewCalc().InBN256().WithNeg()
+
+	//fmt.Println("dec", dec, new(bn256.GT).ScalarBaseMult(big.NewInt(0)))
+	res, err := calc.BabyStepGiantStep(dec, new(bn256.GT).ScalarBaseMult(big.NewInt(1)))
+
+	return res, err
+}

--- a/innerprod/fullysec/part_fh_ipe.go
+++ b/innerprod/fullysec/part_fh_ipe.go
@@ -237,13 +237,21 @@ func (d *PartFHIPE) Encrypt(x data.Vector, pubKey *PartFHIPEPubKey) (data.Vector
 // Decrypt accepts the encrypted vector, functional encryption key, and
 // a plaintext vector y. It returns the inner product of x and y.
 // If decryption failed, error is returned.
-func (d *PartFHIPE) Decrypt(cipher data.VectorG1, key data.VectorG2) (*big.Int, error) {
+func (d *PartFHIPE) PartDecrypt(cipher data.VectorG1, feKey data.VectorG2) *bn256.GT {
 	dec := new(bn256.GT).ScalarBaseMult(big.NewInt(0))
-	fmt.Println(len(key), len(cipher), d.Params.L + 4)
 	for i := 0; i < d.Params.L + 4; i++ {
-		pairedI := bn256.Pair(cipher[i], key[i])
+		pairedI := bn256.Pair(cipher[i], feKey[i])
 		dec = new(bn256.GT).Add(pairedI, dec)
 	}
+
+	return dec
+}
+
+// Decrypt accepts the encrypted vector, functional encryption key, and
+// a plaintext vector y. It returns the inner product of x and y.
+// If decryption failed, error is returned.
+func (d *PartFHIPE) Decrypt(cipher data.VectorG1, feKey data.VectorG2) (*big.Int, error) {
+	dec := d.PartDecrypt(cipher, feKey)
 
 	//bSquared := new(big.Int).Mul(d.Params.Bound, d.Params.Bound)
 	//bound := new(big.Int).Mul(big.NewInt(int64(d.Params.L)), bSquared)

--- a/innerprod/fullysec/part_fh_ipe.go
+++ b/innerprod/fullysec/part_fh_ipe.go
@@ -20,113 +20,116 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/fentec-project/gofe/data"
-	"github.com/fentec-project/gofe/sample"
 	"github.com/fentec-project/bn256"
+	"github.com/fentec-project/gofe/data"
 	"github.com/fentec-project/gofe/internal/dlog"
+	"github.com/fentec-project/gofe/sample"
 )
 
-// DamgardParams includes public parameters for the Damgard inner
-// product scheme.
+// PartFHIPEParams includes public parameters for the partially
+// function hiding inner product scheme.
 // L (int): The length of vectors to be encrypted.
-// Bound (int): The value by which coordinates of vectors x and y are bounded.
-// G (int): Generator of a cyclic group Z_P: G**(Q) = 1 (mod P).
-// H (int): Generator of a cyclic group Z_P: H**(Q) = 1 (mod P).
-// P (int): Modulus - we are operating in a cyclic group Z_P.
-// Q (int): Multiplicative order of G and H.
+// Bound (*big.Int): The value by which coordinates of vectors x and y are bounded.
 type PartFHIPEParams struct {
-	L int
-	K int
-	Bound      *big.Int
-	p big.Int
+	L     int
+	Bound *big.Int
 }
 
-// Damgard represents a scheme instantiated from the DDH assumption
-// based on DDH variant of:
-// Agrawal, Shweta, Libert, and Stehle:
-// "Fully secure functional encryption for inner products,
-// from standard assumptions".
+// PartFHIPE represents a partially function hiding inner product
+// FE scheme. A partially function hiding scheme is a public
+// key scheme that allows to encrypt only vectors from a chosen
+// subspace. This way a functional encryption key does not reveal
+// its corresponding inner product function. Decryption of a
+// ciphertext using FE key can be done without knowing the function.
+// Additionally, owner of the secret key can encrypt any vector.
+//
+// The scheme is based on the paper by Romain Gay:
+// "A New Paradigm for Public-Key Functional Encryption for
+// Degree-2 Polynomials".
 type PartFHIPE struct {
 	Params *PartFHIPEParams
 }
 
-// NewDamgard configures a new instance of the scheme.
-// It accepts the length of input vectors l, the bit length of the
-// modulus (we are operating in the Z_p group), and a bound by which
-// coordinates of input vectors are bounded.
+// NewPartFHIPE configures a new instance of the scheme.
+// It accepts the length of input vectors l, and a bound by which
+// the coordinates of input vectors are bounded.
 //
 // It returns an error in case the scheme could not be properly
 // configured, or if precondition l * bound² is >= order of the cyclic
 // group.
-func NewPartFHIPE(l, k int, bound *big.Int) *PartFHIPE {
+func NewPartFHIPE(l int, bound *big.Int) (*PartFHIPE, error) {
+	var b *big.Int
+	if bound != nil {
+		b = new(big.Int).Set(bound)
+		bSquared := new(big.Int).Mul(bound, bound)
+		upper := new(big.Int).Mul(big.NewInt(int64(2*l)), bSquared)
+		if upper.Cmp(bn256.Order) > 0 {
+			return nil, fmt.Errorf("bound and l too big for the group")
+		}
+	}
+
 	return &PartFHIPE{
 		Params: &PartFHIPEParams{
 			L:     l,
-			K: k,
-			Bound: bound,
+			Bound: b,
 		},
-	}
+	}, nil
 }
 
-
-// NewDamgardFromParams takes configuration parameters of an existing
-// Damgard scheme instance, and reconstructs the scheme with same configuration
-// parameters. It returns a new Damgard instance.
+// NewPartFHIPEFromParams takes configuration parameters of an existing
+// PartFHIPE instance, and reconstructs the scheme with the same configuration
+// parameters. It returns a new PartFHIPE instance.
 func NewPartFHIPEFromParams(params *PartFHIPEParams) *PartFHIPE {
 	return &PartFHIPE{
 		Params: params,
 	}
 }
 
-// DamgardSecKey is a secret key for Damgard scheme.
+// PartFHIPESecKey is a secret key for the partially function hiding
+// inner product scheme.
 type PartFHIPESecKey struct {
-	B data.VectorG2
+	B data.Vector
 	V data.Matrix
 	U data.Matrix
 }
 
-// DamgardSecKey is a secret key for Damgard scheme.
+// PartFHIPEPubKey is a public key for the partially function hiding
+// inner product scheme.
 type PartFHIPEPubKey struct {
-	A data.VectorG1
-	Ua data.VectorG1
+	A   data.VectorG1
+	Ua  data.VectorG1
 	VtM data.MatrixG1
+	M   data.Matrix
 	MG1 data.MatrixG1
 }
 
-// GenerateMasterKeys generates a master secret key and master
-// public key for the scheme. It returns an error in case master keys
-// could not be generated.
+// GenerateKeys generates a master secret key and public key for the scheme.
+// It returns an error in case the keys could not be generated.
 func (d *PartFHIPE) GenerateKeys(M data.Matrix) (*PartFHIPEPubKey, *PartFHIPESecKey, error) {
-	if d.Params.L != M.Rows() || d.Params.K != M.Cols() {
+	if d.Params.L != M.Rows() {
 		return nil, nil, fmt.Errorf("dimensions of the given matrix do not match dimensions of the scheme")
 	}
 	sampler := sample.NewUniform(bn256.Order)
-	//sampler = sample.NewUniformRange(big.NewInt(0), big.NewInt(1))
-	//sampler2 := sample.NewUniformRange(big.NewInt(0), big.NewInt(1))
-
 
 	aVec := make(data.Vector, 2)
-	bVec := make(data.Vector, 2)
-
 	aVec[0] = big.NewInt(1)
-	bVec[0] = big.NewInt(1)
-
 	x, err := sampler.Sample()
 	if err != nil {
 		return nil, nil, err
 	}
 	aVec[1] = x
 
+	b := make(data.Vector, 2)
+	b[0] = big.NewInt(1)
 	x, err = sampler.Sample()
 	if err != nil {
 		return nil, nil, err
 	}
-	bVec[1] = x
+	b[1] = x
 
 	a := aVec.MulG1()
-	b := bVec.MulG2()
 
-	U, err := data.NewRandomMatrix(d.Params.L + 2, 2, sampler)
+	U, err := data.NewRandomMatrix(d.Params.L+2, 2, sampler)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -140,78 +143,82 @@ func (d *PartFHIPE) GenerateKeys(M data.Matrix) (*PartFHIPEPubKey, *PartFHIPESec
 	if err != nil {
 		return nil, nil, err
 	}
+	UaVec = UaVec.Mod(bn256.Order)
+
 	Ua := UaVec.MulG1()
 
 	VtMMat, err := V.Transpose().Mul(M)
 	if err != nil {
 		return nil, nil, err
 	}
+	VtMMat = VtMMat.Mod(bn256.Order)
 	VtM := VtMMat.MulG1()
 
 	MG1 := M.MulG1()
 
-	return &PartFHIPEPubKey{A: a, Ua: Ua, VtM: VtM, MG1: MG1},
-		   &PartFHIPESecKey{B: b, V: V, U: U},
-		   nil
+	return &PartFHIPEPubKey{A: a, Ua: Ua, VtM: VtM, M: M.Copy(), MG1: MG1},
+		&PartFHIPESecKey{B: b, V: V, U: U},
+		nil
 }
 
-// TODO: maybe optimize to b being vector
-// DeriveKey takes master secret key and input vector y, and returns the
+// DeriveKey takes input vector y and master secret key, and returns the
 // functional encryption key. In case the key could not be derived, it
 // returns an error.
 func (d *PartFHIPE) DeriveKey(y data.Vector, secKey *PartFHIPESecKey) (data.VectorG2, error) {
-	if err := y.CheckBound(d.Params.Bound); err != nil {
-		return nil, err
+	if len(y) != d.Params.L {
+		return nil, fmt.Errorf("the dimension of the given vector does not match the dimension of the scheme")
+	}
+	if d.Params.Bound != nil {
+		if err := y.CheckBound(d.Params.Bound); err != nil {
+			return nil, err
+		}
 	}
 
 	sampler := sample.NewUniform(bn256.Order)
-	//sampler = sample.NewUniformRange(big.NewInt(0), big.NewInt(1))
 
 	s, err := sampler.Sample()
 	if err != nil {
 		return nil, err
 	}
 
-	//key2 := make(data.VectorG2, d.Params.L + 2)
 	bs := secKey.B.MulScalar(s)
+	bs = bs.Mod(bn256.Order)
 
-	Vbs, err := secKey.V.MatMulVecG2(bs)
+	Vbs, err := secKey.V.MulVec(bs)
 	if err != nil {
 		return nil, err
 	}
-	yG2 := y.MulG2()
-	YVbs := Vbs.Add(yG2)
+	YVbs := y.Add(Vbs)
+	YVbs = YVbs.Mod(bn256.Order)
 	key2 := append(bs, YVbs...)
-	//key2[:2] = bs
-	//key2[2:] = YVbs
 
-	key1, err := secKey.U.Transpose().MatMulVecG2(key2)
+	key1, err := secKey.U.Transpose().MulVec(key2)
 	if err != nil {
 		return nil, err
 	}
 	key1 = key1.Neg()
+	key1 = key1.Mod(bn256.Order)
 
-	//key := make(data.VectorG2, d.Params.L + 4)
-	//key[:2] = key1
-	//key[2:] = key2
 	key := append(key1, key2...)
 
-	return key, nil
+	return key.MulG2(), nil
 }
 
-
-
-
-// Encrypt encrypts input vector x with the provided master public key.
-// It returns a ciphertext vector. If encryption failed, error is returned.
-func (d *PartFHIPE) Encrypt(x data.Vector, pubKey *PartFHIPEPubKey) (data.VectorG1, error) {
-	// todo: different check
-	if err := x.CheckBound(d.Params.Bound); err != nil {
+// Encrypt on input vector t encrypts vector x = Mt with the provided public key.
+// It returns a ciphertext vector. Entries of Mt should not be greater then bound.
+// If encryption failed, an error is returned.
+func (d *PartFHIPE) Encrypt(t data.Vector, pubKey *PartFHIPEPubKey) (data.VectorG1, error) {
+	x, err := pubKey.M.MulVec(t)
+	if err != nil {
 		return nil, err
+	}
+	if d.Params.Bound != nil {
+		if err := x.CheckBound(d.Params.Bound); err != nil {
+			return nil, err
+		}
 	}
 
 	sampler := sample.NewUniform(bn256.Order)
-	//sampler = sample.NewUniformRange(big.NewInt(0), big.NewInt(1))
 
 	r, err := sampler.Sample()
 	if err != nil {
@@ -221,43 +228,87 @@ func (d *PartFHIPE) Encrypt(x data.Vector, pubKey *PartFHIPEPubKey) (data.Vector
 	c := pubKey.A.MulScalar(r)
 	Uc := pubKey.Ua.MulScalar(r)
 
-	Mx := pubKey.MG1.MulVector(x)
-	VtMx := pubKey.VtM.MulVector(x)
-	VtMxNeg := VtMx.Neg()
-	cipher2 := append(VtMxNeg, Mx...)
+	Mt := pubKey.MG1.MulVector(t)
+	VtMt := pubKey.VtM.MulVector(t)
+	VtMxNeg := VtMt.Neg()
+	cipher2 := append(VtMxNeg, Mt...)
 	cipher2add := cipher2.Add(Uc)
 
 	cipher := append(c, cipher2add...)
 
-	//fmt.Println(c, cipher2, cipher)
+	return cipher, nil
+}
+
+// SecEncrypt encrypts an arbitrary vector x using public key but additionally
+// the master secret key is needed. It returns a ciphertext vector.
+// If encryption failed, error is returned.
+func (d *PartFHIPE) SecEncrypt(x data.Vector, pubKey *PartFHIPEPubKey, secKey *PartFHIPESecKey) (data.VectorG1, error) {
+	if len(x) != d.Params.L {
+		return nil, fmt.Errorf("the dimension of the given vector does not match the dimension of the scheme")
+	}
+	if d.Params.Bound != nil {
+		if err := x.CheckBound(d.Params.Bound); err != nil {
+			return nil, err
+		}
+	}
+
+	sampler := sample.NewUniform(bn256.Order)
+
+	r, err := sampler.Sample()
+	if err != nil {
+		return nil, err
+	}
+
+	c := pubKey.A.MulScalar(r)
+	Uc := pubKey.Ua.MulScalar(r)
+
+	Vtx, err := secKey.V.Transpose().MulVec(x)
+	if err != nil {
+		return nil, err
+	}
+	Vtx = Vtx.Neg().Mod(bn256.Order)
+
+	VtxG1 := Vtx.MulG1()
+	xG1 := x.MulG1()
+	cipher2 := append(VtxG1, xG1...)
+	cipher2add := cipher2.Add(Uc)
+
+	cipher := append(c, cipher2add...)
 
 	return cipher, nil
 }
 
-// Decrypt accepts the encrypted vector, functional encryption key, and
-// a plaintext vector y. It returns the inner product of x and y.
-// If decryption failed, error is returned.
-func (d *PartFHIPE) PartDecrypt(cipher data.VectorG1, feKey data.VectorG2) *bn256.GT {
+// PartDecrypt accepts the encrypted vector and functional encryption key. It
+// returns the value d*[bn256.GT] where d is the inner product of x and y.
+// To obtain a final result, calculating the discrete logarithm is needed.
+func (d *PartFHIPE) PartDecrypt(cipher data.VectorG1, feKey data.VectorG2) (*bn256.GT, error) {
+	if len(cipher) != d.Params.L+4 || len(feKey) != d.Params.L+4 {
+		return nil, fmt.Errorf("the length of FE key or ciphertext does not match the dimension of the scheme")
+	}
 	dec := new(bn256.GT).ScalarBaseMult(big.NewInt(0))
-	for i := 0; i < d.Params.L + 4; i++ {
+	for i := 0; i < d.Params.L+4; i++ {
 		pairedI := bn256.Pair(cipher[i], feKey[i])
 		dec = new(bn256.GT).Add(pairedI, dec)
 	}
 
-	return dec
+	return dec, nil
 }
 
-// Decrypt accepts the encrypted vector, functional encryption key, and
-// a plaintext vector y. It returns the inner product of x and y.
-// If decryption failed, error is returned.
+// Decrypt accepts the encrypted vector and functional encryption key.
+// It returns the inner product of x and y. If decryption failed, error is returned.
 func (d *PartFHIPE) Decrypt(cipher data.VectorG1, feKey data.VectorG2) (*big.Int, error) {
-	dec := d.PartDecrypt(cipher, feKey)
-
-	//bSquared := new(big.Int).Mul(d.Params.Bound, d.Params.Bound)
-	//bound := new(big.Int).Mul(big.NewInt(int64(d.Params.L)), bSquared)
+	dec, err := d.PartDecrypt(cipher, feKey)
+	if err != nil {
+		return nil, err
+	}
 	calc := dlog.NewCalc().InBN256().WithNeg()
 
-	//fmt.Println("dec", dec, new(bn256.GT).ScalarBaseMult(big.NewInt(0)))
+	if d.Params.Bound != nil {
+		bSquared := new(big.Int).Mul(d.Params.Bound, d.Params.Bound)
+		bound := new(big.Int).Mul(big.NewInt(int64(d.Params.L)), bSquared)
+		calc = calc.WithBound(bound)
+	}
+
 	res, err := calc.BabyStepGiantStep(dec, new(bn256.GT).ScalarBaseMult(big.NewInt(1)))
 
 	return res, err

--- a/innerprod/fullysec/part_fh_ipe.go
+++ b/innerprod/fullysec/part_fh_ipe.go
@@ -212,7 +212,7 @@ func (d *PartFHIPE) DeriveKey(y data.Vector, secKey *PartFHIPESecKey) (data.Vect
 // Encrypt on input vector t encrypts vector x = Mt with the provided public key
 // (matrix M is specified in the public key). It returns a ciphertext vector.
 // Entries of Mt should not be greater then bound.
-// If encryption an failed, an error is returned.
+// If encryption fails, an error is returned.
 func (d *PartFHIPE) Encrypt(t data.Vector, pubKey *PartFHIPEPubKey) (data.VectorG1, error) {
 	x, err := pubKey.M.MulVec(t)
 	if err != nil {

--- a/innerprod/fullysec/part_fh_ipe_test.go
+++ b/innerprod/fullysec/part_fh_ipe_test.go
@@ -107,6 +107,9 @@ func TestPartFHIPE(te *testing.T) {
 
 	// check the correctness of the results
 	Mt, err := m.MulVec(t)
+	if err != nil {
+		te.Fatalf("Error calculating the inner product: %v", err)
+	}
 	yMtCheck, err := y.Dot(Mt)
 	if err != nil {
 		te.Fatalf("Error calculating the inner product: %v", err)

--- a/innerprod/fullysec/part_fh_ipe_test.go
+++ b/innerprod/fullysec/part_fh_ipe_test.go
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2018 XLAB d.o.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fullysec_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/fentec-project/gofe/data"
+	"github.com/fentec-project/gofe/innerprod/fullysec"
+	"github.com/fentec-project/gofe/sample"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPartFHIPE(t *testing.T) {
+	// choose the parameters for the encryption and build the scheme
+	l := 50
+	k := 5
+	bound := big.NewInt(2)
+	sampler := sample.NewUniform(bound)
+	//sampler = sample.NewUniformRange(big.NewInt(1), big.NewInt(2))
+
+
+	m, err := data.NewRandomMatrix(l, k, sampler)
+	if err != nil {
+		t.Fatalf("Error during random matrix generation: %v", err)
+	}
+	//m[0][0] = big.NewInt(1)
+	//det, err := m.Determinant()
+	//if err != nil || det.Sign() == 0 {
+	//	t.Fatalf("Error during random matrix generation: %v", err)
+	//}
+
+
+
+
+	partfhipe:= fullysec.NewPartFHIPE(l, k, bound)
+
+	// generate master key
+	pubKey, secKey, err := partfhipe.GenerateKeys(m)
+	if err != nil {
+		t.Fatalf("Error during master key generation: %v", err)
+	}
+
+	fmt.Println("pub", pubKey)
+	fmt.Println("sec", secKey)
+
+	// sample a vector that will be encrypted
+	x, err := data.NewRandomVector(k, sampler)
+	if err != nil {
+		t.Fatalf("Error during random vector generation: %v", err)
+	}
+
+	// simulate the instantiation of an encryptor (which should know the master key)
+	encryptor := fullysec.NewPartFHIPEFromParams(partfhipe.Params)
+	// encrypt the vector
+	ciphertext, err := encryptor.Encrypt(x, pubKey)
+	if err != nil {
+		t.Fatalf("Error during encryption: %v", err)
+	}
+
+	// sample a inner product vector
+	y, err := data.NewRandomVector(l, sampler)
+	if err != nil {
+		t.Fatalf("Error during random vecotr generation: %v", err)
+	}
+
+	// derive a functional key for vector y
+	feKey, err := partfhipe.DeriveKey(y, secKey)
+	if err != nil {
+		t.Fatalf("Error during key derivation: %v", err)
+	}
+
+	//fmt.Println(feKey, pubKey)
+	Mx, err := m.MulVec(x)
+	yMyCheck, err := y.Dot(Mx)
+
+	fmt.Println(y, m, x, yMyCheck)
+
+
+	// simulate a decryptor
+	decryptor := fullysec.NewPartFHIPEFromParams(partfhipe.Params)
+	// decryptor decrypts the inner-product without knowing
+	// vectors x and y
+	xMy, err := decryptor.Decrypt(ciphertext, feKey)
+	if err != nil {
+		t.Fatalf("Error during decryption: %v", err)
+	}
+	fmt.Println(xMy, yMyCheck)
+
+	// check the correctness of the result
+
+	if err != nil {
+		t.Fatalf("Error during inner product calculation")
+	}
+
+
+
+
+	if err != nil {
+		t.Fatalf("Error during inner product calculation")
+	}
+	assert.Equal(t, xMy.Cmp(yMyCheck), 0, "obtained incorrect inner product")
+}

--- a/innerprod/fullysec/part_fh_ipe_test.go
+++ b/innerprod/fullysec/part_fh_ipe_test.go
@@ -40,6 +40,7 @@ func TestPartFHIPE(te *testing.T) {
 	// choose a subspace in which encryption will be allowed
 	k := 5 // dimension of the subspace
 	// the subspace is given by the columns of the matrix m
+	// we sample m with not too big inputs
 	samplerM := sample.NewUniform(new(big.Int).Div(bound, big.NewInt(int64(k))))
 	m, err := data.NewRandomMatrix(l, k, samplerM)
 	if err != nil {
@@ -92,13 +93,13 @@ func TestPartFHIPE(te *testing.T) {
 
 	// simulate a decryptor
 	decryptor := fullysec.NewPartFHIPEFromParams(partfhipe.Params)
-	// decryptor decrypts the inner-product yMt without knowing
+	// decryptor decrypts the inner-product y^TMt without knowing
 	// vectors Mt and y
 	yMt, err := decryptor.Decrypt(ciphertextMt, feKey)
 	if err != nil {
 		te.Fatalf("Error during decryption: %v", err)
 	}
-	// and decrypts the inner-product xy without knowing
+	// and decrypts the inner-product x^Ty without knowing
 	// vectors x and y
 	yx, err := decryptor.Decrypt(ciphertextX, feKey)
 	if err != nil {

--- a/innerprod/fullysec/part_fh_ipe_test.go
+++ b/innerprod/fullysec/part_fh_ipe_test.go
@@ -69,7 +69,7 @@ func TestPartFHIPE(te *testing.T) {
 		te.Fatalf("Error during encryption: %v", err)
 	}
 
-	// owner of the secret key key encrypt an arbitrary vector
+	// the owner of the secret key encrypts an arbitrary vector
 	x, err := data.NewRandomVector(l, sampler)
 	if err != nil {
 		te.Fatalf("Error during random vector generation: %v", err)

--- a/innerprod/simple/ddh_test.go
+++ b/innerprod/simple/ddh_test.go
@@ -35,7 +35,7 @@ type ddhTestParam struct {
 func testSimpleDDHFromParam(t *testing.T, param ddhTestParam) {
 	l := 3
 	bound := new(big.Int).Exp(big.NewInt(2), big.NewInt(10), nil)
-	sampler := sample.NewUniformRange(new(big.Int).Neg(bound), bound)
+	sampler := sample.NewUniformRange(new(big.Int).Add(new(big.Int).Neg(bound), big.NewInt(1)), bound)
 
 	var simpleDDH *simple.DDH
 	var err error

--- a/internal/dlog/pollard_rho_test.go
+++ b/internal/dlog/pollard_rho_test.go
@@ -163,7 +163,6 @@ func TestPollardRhoFactorizationBounded(t *testing.T) {
 }
 
 func getSmoothNumber(B, numPrimes, maxPower int) *big.Int {
-
 	// find the index of the maximal allowed factor
 	indexBound := len(smallPrimes)
 	for i, p := range smallPrimes {

--- a/quadratic/quad.go
+++ b/quadratic/quad.go
@@ -169,20 +169,20 @@ func (q *Quad) GenerateKeys() (*QuadPubKey, *QuadSecKey, error) {
 
 	// assemble matrix M
 	// upper part
-	IdVB, err := data.Id(q.Params.M, q.Params.M).JoinCols(VBMat)
+	IdnVB, err := data.Identity(q.Params.M, q.Params.M).JoinCols(VBMat)
 	if err != nil {
 		return nil, nil, err
 	}
 	aMat := data.Matrix{a}.Transpose()
-	aTensorIdVB := aMat.Tensor(IdVB)
-	aTensorIdVB = aTensorIdVB.Mod(bn256.Order)
-	M0, err := aTensorIdVB.JoinCols(data.NewConstantMatrix(2*q.Params.M, q.Params.N*2, big.NewInt(0)))
+	aTensorIdnVB := aMat.Tensor(IdnVB)
+	aTensorIdnVB = aTensorIdnVB.Mod(bn256.Order)
+	M0, err := aTensorIdnVB.JoinCols(data.NewConstantMatrix(2*q.Params.M, q.Params.N*2, big.NewInt(0)))
 	if err != nil {
 		return nil, nil, err
 	}
 	// lower part
-	IdB := data.Id(q.Params.N, q.Params.N).Tensor(B)
-	M1, err := data.NewConstantMatrix(q.Params.N*3, IdVB.Cols(), big.NewInt(0)).JoinCols(IdB)
+	IdnB := data.Identity(q.Params.N, q.Params.N).Tensor(B)
+	M1, err := data.NewConstantMatrix(q.Params.N*3, IdnVB.Cols(), big.NewInt(0)).JoinCols(IdnB)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -215,7 +215,7 @@ type QuadCipher struct {
 // If the ciphertext could not be generated, it returns an error.
 func (q *Quad) Encrypt(x, y data.Vector, pubKey *QuadPubKey) (*QuadCipher, error) {
 	if len(x) != q.Params.N || len(y) != q.Params.M {
-		return nil, fmt.Errorf("dimensions of vectors are incorect")
+		return nil, fmt.Errorf("dimensions of vectors are incorrect")
 	}
 	if err := x.CheckBound(q.Params.Bound); err != nil {
 		return nil, err
@@ -259,7 +259,7 @@ func (q *Quad) Encrypt(x, y data.Vector, pubKey *QuadPubKey) (*QuadCipher, error
 // It returns an error if the key could not be derived.
 func (q *Quad) DeriveKey(secKey *QuadSecKey, F data.Matrix) (data.VectorG2, error) {
 	if F.Rows() != q.Params.N || F.Cols() != q.Params.M {
-		return nil, fmt.Errorf("dimensions of the given matrix are incorect")
+		return nil, fmt.Errorf("dimensions of the given matrix are incorrect")
 	}
 
 	UtF, err := secKey.U.Transpose().Mul(F)
@@ -289,7 +289,7 @@ func (q *Quad) Decrypt(c *QuadCipher, feKey data.VectorG2, F data.Matrix) (*big.
 		return nil, fmt.Errorf("dimensions of the given FE key are incorrect")
 	}
 	if F.Rows() != q.Params.N || F.Cols() != q.Params.M {
-		return nil, fmt.Errorf("dimensions of the given matrix are incorect")
+		return nil, fmt.Errorf("dimensions of the given matrix are incorrect")
 	}
 
 	d, err := q.Params.PartFHIPE.PartDecrypt(c.CIPE, feKey)

--- a/quadratic/quad.go
+++ b/quadratic/quad.go
@@ -35,6 +35,7 @@ import (
 // Bound (*big.Int): The value by which coordinates of vectors x, y and F are bounded.
 type QuadParams struct {
 	PartFHIPE *fullysec.PartFHIPE
+	// N should be greater or equal to M
 	N         int // length of vectors x
 	M         int // length of vectors y
 	// The value by which elements of vectors x, y, and the
@@ -46,7 +47,7 @@ type QuadParams struct {
 // More precisely, it allows to encrypt vectors x and y using public key,
 // derive a functional encryption key corresponding to a matrix F, and
 // decrypt value x^T * F * y from encryption of x, y and functional key, without
-// reveling and other information about x or y. The scheme is based on
+// reveling any other information about x or y. The scheme is based on
 // a paper by Romain Gay: "A New Paradigm for Public-Key Functional
 // Encryption for Degree-2 Polynomials".
 // The scheme uses an underling partially function hiding inner product

--- a/quadratic/quad.go
+++ b/quadratic/quad.go
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2018 XLAB d.o.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quadratic
+
+import (
+	"math/big"
+
+	"github.com/fentec-project/bn256"
+	"github.com/fentec-project/gofe/data"
+	"github.com/fentec-project/gofe/internal/dlog"
+	"github.com/fentec-project/gofe/sample"
+	"github.com/fentec-project/gofe/innerprod/fullysec"
+)
+
+// SGP implements efficient FE scheme for quadratic multi-variate polynomials
+// based on Dufour Sans, Gay and Pointcheval:
+// "Reading in the Dark: Classifying Encrypted Digits with
+// Functional Encryption".
+// See paper: https://eprint.iacr.org/2018/206.pdf which is based on bilinear pairings.
+// It offers adaptive security under chosen-plaintext attacks (IND-CPA security).
+// This is a secret key scheme, meaning that we need a master secret key to
+// encrypt the messages.
+// Assuming input vectors x and y, the SGP scheme allows the decryptor to
+// calculate x^T * F * y, where F is matrix that represents the function,
+// and vectors x, y are only known to the encryptor, but not to decryptor.
+type Quad struct {
+	*fullysec.PartFHIPE
+	// length of vectors x and y (matrix F is N x N)
+	N int
+	// Modulus for ciphertext and keys
+	M int
+
+	// The value by which elements of vectors x, y, and the
+	// matrix F are bounded.
+	Bound *big.Int
+
+	GCalc    *dlog.CalcBN256
+	GInvCalc *dlog.CalcBN256
+}
+
+// NewSGP configures a new instance of the SGP scheme.
+// It accepts the length of input vectors n and the upper bound b
+// for coordinates of input vectors x, y, and the function
+// matrix F.
+func NewQuad(n, m int, b *big.Int) *Quad {
+	partFHIPE := fullysec.NewPartFHIPE(n, m, b)
+
+	return &Quad{
+		PartFHIPE: partFHIPE,
+		N:        n,
+		M:        m,
+		Bound:    b,
+		GCalc:    dlog.NewCalc().InBN256(), //.WithBound(b),
+		GInvCalc: dlog.NewCalc().InBN256(), //.WithBound(b),
+	}
+}
+
+// SGPSecKey represents a master secret key for the SGP scheme.
+// An instance of this type is returned by the
+// GenerateMasterKey method.
+type QuadPubKey struct {
+	Ua data.VectorG1
+	VB data.VectorG2
+	PubIp fullysec.PartFHIPEPubKey
+}
+
+type QuadSecKey struct {
+	U data.Vector
+	V data.Vector
+	SecIp fullysec.PartFHIPESecKey
+}
+
+// GenerateMasterKey generates a master secret key for the
+// SGP scheme. It returns an error if the secret key could
+// not be generated.
+func (q *Quad) GenerateMasterKey() (*QuadPubKey, error) {
+	// msk is random s, t from Z_p^n
+	sampler := sample.NewUniform(q.Mod)
+	s, err := data.NewRandomVector(q.N, sampler)
+	if err != nil {
+		return nil, err
+	}
+	t, err := data.NewRandomVector(q.N, sampler)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewSGPSecKey(s, t), nil
+}
+
+// SGPCipher represents a ciphertext. An instance of this type
+// is returned as a result of the Encrypt method.
+type SGPCipher struct {
+	G1MulGamma *bn256.G1
+	AMulG1     []data.VectorG1
+	BMulG2     []data.VectorG2
+}
+
+// NewSGPCipher constructs an instance of SGPCipher.
+func NewSGPCipher(g1MulGamma *bn256.G1, aMulG1 []data.VectorG1,
+	bMulG2 []data.VectorG2) *SGPCipher {
+	return &SGPCipher{
+		G1MulGamma: g1MulGamma,
+		AMulG1:     aMulG1,
+		BMulG2:     bMulG2,
+	}
+}
+
+// Encrypt encrypts input vectors x and y with the
+// master secret key msk. It returns the appropriate ciphertext.
+// If ciphertext could not be generated, it returns an error.
+func (q *SGP) Encrypt(x, y data.Vector, msk *SGPSecKey) (*SGPCipher, error) {
+	sampler := sample.NewUniform(q.Mod)
+	gamma, err := sampler.Sample()
+	if err != nil {
+		return nil, err
+	}
+
+	W, err := data.NewRandomMatrix(2, 2, sampler)
+	if err != nil {
+		return nil, err
+	}
+
+	WInv, err := W.InverseMod(q.Mod)
+	if err != nil {
+		return nil, err
+	}
+
+	WInvT := WInv.Transpose()
+
+	a := make([]data.Vector, q.N)
+	b := make([]data.Vector, q.N)
+	for i := 0; i < q.N; i++ {
+		// v = (x_i, gamma * s_i)
+		tmp := new(big.Int).Mul(gamma, msk.S[i])
+		tmp.Mod(tmp, q.Mod)
+		v := data.NewVector([]*big.Int{x[i], tmp})
+		ai, err := WInvT.MulVec(v)
+		if err != nil {
+			return nil, err
+		}
+		a[i] = ai.Mod(q.Mod)
+
+		// v = (y_i, -t_i)
+		tiNeg := new(big.Int).Sub(q.Mod, msk.T[i])
+		bi, err := W.MulVec(data.NewVector([]*big.Int{y[i], tiNeg}))
+		if err != nil {
+			return nil, err
+		}
+		b[i] = bi.Mod(q.Mod)
+	}
+	aMulG1 := make([]data.VectorG1, q.N)
+	bMulG2 := make([]data.VectorG2, q.N)
+	for i := range a {
+		aMulG1[i] = a[i].MulG1()
+		bMulG2[i] = b[i].MulG2()
+	}
+
+	c := NewSGPCipher(new(bn256.G1).ScalarBaseMult(gamma), aMulG1, bMulG2)
+
+	return c, nil
+}
+
+// DeriveKey derives the functional encryption key for the scheme.
+// It returns an error if the key could not be derived.
+func (q *SGP) DeriveKey(msk *SGPSecKey, F data.Matrix) (*bn256.G2, error) {
+	// F is matrix and represents function (x, y) -> Σ f_i,j * x_i * y_i.
+	// Functional encryption key is g2 * f(s, t).
+	v, err := F.MulXMatY(msk.S, msk.T)
+	if err != nil {
+		return nil, err
+	}
+
+	tmp := new(big.Int).Set(v)
+	e := new(bn256.G2).ScalarBaseMult(big.NewInt(1))
+	if tmp.Cmp(big.NewInt(0)) < 0 {
+		tmp.Neg(tmp)
+		e.Neg(e)
+	}
+
+	return new(bn256.G2).ScalarMult(e, tmp), nil
+}
+
+// Decrypt decrypts the ciphertext c with the derived functional
+// encryption key key in order to obtain function x^T * F * y.
+func (q *SGP) Decrypt(c *SGPCipher, key *bn256.G2, F data.Matrix) (*big.Int, error) {
+	prod := bn256.Pair(c.G1MulGamma, key)
+
+	for i, row := range F {
+		for j, rowEl := range row {
+			if rowEl.Sign() != 0 {
+				e1 := bn256.Pair(c.AMulG1[i][0], c.BMulG2[j][0])
+				e2 := bn256.Pair(c.AMulG1[i][1], c.BMulG2[j][1])
+				e := new(bn256.GT).Add(e1, e2)
+
+				tmp := new(big.Int).Set(rowEl)
+				if tmp.Sign() == -1 {
+					tmp.Neg(tmp)
+					e.Neg(e)
+				}
+
+				t := new(bn256.GT).ScalarMult(e, tmp)
+				prod.Add(prod, t)
+			}
+		}
+	}
+
+	g1gen := new(bn256.G1).ScalarBaseMult(big.NewInt(1))
+	g2gen := new(bn256.G2).ScalarBaseMult(big.NewInt(1))
+	g := bn256.Pair(g1gen, g2gen)
+
+	// b: b = n^2 * b^3
+	b3 := new(big.Int).Exp(q.Bound, big.NewInt(3), nil)
+	n2 := new(big.Int).Exp(big.NewInt(int64(q.N)), big.NewInt(2), nil)
+	b := new(big.Int).Mul(n2, b3)
+
+	return q.GCalc.WithBound(b).WithNeg().BabyStepGiantStep(prod, g)
+}

--- a/quadratic/quad.go
+++ b/quadratic/quad.go
@@ -24,6 +24,7 @@ import (
 	"github.com/fentec-project/gofe/internal/dlog"
 	"github.com/fentec-project/gofe/sample"
 	"github.com/fentec-project/gofe/innerprod/fullysec"
+	"fmt"
 )
 
 // SGP implements efficient FE scheme for quadratic multi-variate polynomials
@@ -38,7 +39,7 @@ import (
 // calculate x^T * F * y, where F is matrix that represents the function,
 // and vectors x, y are only known to the encryptor, but not to decryptor.
 type Quad struct {
-	*fullysec.PartFHIPE
+	PartFHIPE *fullysec.PartFHIPE
 	// length of vectors x and y (matrix F is N x N)
 	N int
 	// Modulus for ciphertext and keys
@@ -57,7 +58,7 @@ type Quad struct {
 // for coordinates of input vectors x, y, and the function
 // matrix F.
 func NewQuad(n, m int, b *big.Int) *Quad {
-	partFHIPE := fullysec.NewPartFHIPE(n, m, b)
+	partFHIPE := fullysec.NewPartFHIPE(2*m + n*3, (m + 2) + n*2, bn256.Order)
 
 	return &Quad{
 		PartFHIPE: partFHIPE,
@@ -74,159 +75,200 @@ func NewQuad(n, m int, b *big.Int) *Quad {
 // GenerateMasterKey method.
 type QuadPubKey struct {
 	Ua data.VectorG1
-	VB data.VectorG2
-	PubIp fullysec.PartFHIPEPubKey
+	VB data.MatrixG2
+	PubIPE *fullysec.PartFHIPEPubKey
 }
 
 type QuadSecKey struct {
-	U data.Vector
-	V data.Vector
-	SecIp fullysec.PartFHIPESecKey
+	U data.Matrix
+	V data.Matrix
+	SecIPE *fullysec.PartFHIPESecKey
 }
 
 // GenerateMasterKey generates a master secret key for the
 // SGP scheme. It returns an error if the secret key could
 // not be generated.
-func (q *Quad) GenerateMasterKey() (*QuadPubKey, error) {
-	// msk is random s, t from Z_p^n
-	sampler := sample.NewUniform(q.Mod)
-	s, err := data.NewRandomVector(q.N, sampler)
+func (q *Quad) GenerateKeys() (*QuadPubKey, *QuadSecKey, error) {
+	sampler := sample.NewUniform(bn256.Order)
+	var err error
+
+	// create a vector a over DDH distribution
+	a := make(data.Vector, 2)
+	a[0] = big.NewInt(1)
+	a[1], err = sampler.Sample()
 	if err != nil {
-		return nil, err
-	}
-	t, err := data.NewRandomVector(q.N, sampler)
-	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return NewSGPSecKey(s, t), nil
+	// create a vector a over DLIN distribution
+	B := make(data.Matrix, 3)
+	B[0] = make(data.Vector, 2)
+	B[0][1] = big.NewInt(0)
+	B[0][0], err = sampler.Sample()
+	if err != nil {
+		return nil, nil, err
+	}
+	B[1] = make(data.Vector, 2)
+	B[1][0] = big.NewInt(0)
+	B[1][1], err = sampler.Sample()
+	if err != nil {
+		return nil, nil, err
+	}
+	B[2] = data.NewConstantVector(2, big.NewInt(1))
+
+	// sample matrices U, V and calculate Ua, VB
+	U, err := data.NewRandomMatrix(q.N, 2, sampler)
+	if err != nil {
+		return nil, nil, err
+	}
+	V, err := data.NewRandomMatrix(q.M, 3, sampler)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	UaVec, err := U.MulVec(a)
+	if err != nil {
+		return nil, nil, err
+	}
+	Ua := UaVec.MulG1()
+
+	VBMat, err := V.Mul(B)
+	if err != nil {
+		return nil, nil, err
+	}
+	VB := VBMat.MulG2()
+
+	// assemble matrix M
+	// upper part
+	IdVB, err := data.Id(q.M, q.M).JoinCols(VBMat)
+	if err != nil {
+		return nil, nil, err
+	}
+	aMat := data.Matrix{a}.Transpose()
+	//fmt.Println(aMat, IdVB)
+	//fmt.Println(aMat.Rows(), IdVB.Rows())
+	//fmt.Println(aMat.Cols(), IdVB.Cols())
+	aTensorIdVB := aMat.Tensor(IdVB)
+	//fmt.Println(aTensorIdVB)
+	M0, err := aTensorIdVB.JoinCols(data.NewConstantMatrix(2 * q.M, q.N * 2, big.NewInt(0)))
+	if err != nil {
+		return nil, nil, err
+	}
+	// lower part
+	IdB := data.Id(q.N, q.N).Tensor(B)
+	M1, err := data.NewConstantMatrix(q.N * 3, IdVB.Cols(), big.NewInt(0)).JoinCols(IdB)
+	if err != nil {
+		return nil, nil, err
+	}
+	// together
+	M, err := M0.JoinRows(M1)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pkIPE, skIPE, err := q.PartFHIPE.GenerateKeys(M)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pk := &QuadPubKey{Ua: Ua, VB: VB, PubIPE: pkIPE}
+	sk := &QuadSecKey{U: U, V: V, SecIPE: skIPE}
+
+	return pk, sk, nil
 }
 
-// SGPCipher represents a ciphertext. An instance of this type
-// is returned as a result of the Encrypt method.
-type SGPCipher struct {
-	G1MulGamma *bn256.G1
-	AMulG1     []data.VectorG1
-	BMulG2     []data.VectorG2
-}
-
-// NewSGPCipher constructs an instance of SGPCipher.
-func NewSGPCipher(g1MulGamma *bn256.G1, aMulG1 []data.VectorG1,
-	bMulG2 []data.VectorG2) *SGPCipher {
-	return &SGPCipher{
-		G1MulGamma: g1MulGamma,
-		AMulG1:     aMulG1,
-		BMulG2:     bMulG2,
-	}
+type QuadCipher struct {
+	Cx data.VectorG1
+	Cy data.VectorG2
+	CIPE data.VectorG1
 }
 
 // Encrypt encrypts input vectors x and y with the
 // master secret key msk. It returns the appropriate ciphertext.
 // If ciphertext could not be generated, it returns an error.
-func (q *SGP) Encrypt(x, y data.Vector, msk *SGPSecKey) (*SGPCipher, error) {
-	sampler := sample.NewUniform(q.Mod)
-	gamma, err := sampler.Sample()
+func (q *Quad) Encrypt(x, y data.Vector, pubKey *QuadPubKey) (*QuadCipher, error) {
+	sampler := sample.NewUniform(bn256.Order)
+	r, err := sampler.Sample()
+	if err != nil {
+		return nil, err
+	}
+	s, err := data.NewRandomVector(2, sampler)
 	if err != nil {
 		return nil, err
 	}
 
-	W, err := data.NewRandomMatrix(2, 2, sampler)
+	Uar := pubKey.Ua.MulScalar(r)
+	xG1 := x.MulG1()
+	Cx := xG1.Add(Uar)
+
+	VBs := pubKey.VB.MulVector(s)
+	yG2 := y.MulG2()
+	Cy := yG2.Add(VBs)
+
+	ys := append(y, s...)
+	rys := ys.MulScalar(r)
+	xs := x.Tensor(s)
+	xIPE := append(rys, xs...)
+	xIPE = xIPE.Mod(bn256.Order)
+	fmt.Println(xIPE, pubKey.PubIPE)
+	cIPE, err := q.PartFHIPE.Encrypt(xIPE, pubKey.PubIPE)
 	if err != nil {
 		return nil, err
 	}
+	fmt.Println(cIPE)
 
-	WInv, err := W.InverseMod(q.Mod)
-	if err != nil {
-		return nil, err
-	}
-
-	WInvT := WInv.Transpose()
-
-	a := make([]data.Vector, q.N)
-	b := make([]data.Vector, q.N)
-	for i := 0; i < q.N; i++ {
-		// v = (x_i, gamma * s_i)
-		tmp := new(big.Int).Mul(gamma, msk.S[i])
-		tmp.Mod(tmp, q.Mod)
-		v := data.NewVector([]*big.Int{x[i], tmp})
-		ai, err := WInvT.MulVec(v)
-		if err != nil {
-			return nil, err
-		}
-		a[i] = ai.Mod(q.Mod)
-
-		// v = (y_i, -t_i)
-		tiNeg := new(big.Int).Sub(q.Mod, msk.T[i])
-		bi, err := W.MulVec(data.NewVector([]*big.Int{y[i], tiNeg}))
-		if err != nil {
-			return nil, err
-		}
-		b[i] = bi.Mod(q.Mod)
-	}
-	aMulG1 := make([]data.VectorG1, q.N)
-	bMulG2 := make([]data.VectorG2, q.N)
-	for i := range a {
-		aMulG1[i] = a[i].MulG1()
-		bMulG2[i] = b[i].MulG2()
-	}
-
-	c := NewSGPCipher(new(bn256.G1).ScalarBaseMult(gamma), aMulG1, bMulG2)
-
-	return c, nil
+	return &QuadCipher{Cx:Cx, Cy:Cy, CIPE:cIPE}, nil
 }
 
 // DeriveKey derives the functional encryption key for the scheme.
 // It returns an error if the key could not be derived.
-func (q *SGP) DeriveKey(msk *SGPSecKey, F data.Matrix) (*bn256.G2, error) {
-	// F is matrix and represents function (x, y) -> Σ f_i,j * x_i * y_i.
-	// Functional encryption key is g2 * f(s, t).
-	v, err := F.MulXMatY(msk.S, msk.T)
+func (q *Quad) DeriveKey(secKey *QuadSecKey, F data.Matrix) (data.VectorG2, error) {
+	UtF, err := secKey.U.Transpose().Mul(F)
 	if err != nil {
 		return nil, err
 	}
+	UtF = UtF.Mod(bn256.Order)
+	UTFvec := UtF.ToVec()
 
-	tmp := new(big.Int).Set(v)
-	e := new(bn256.G2).ScalarBaseMult(big.NewInt(1))
-	if tmp.Cmp(big.NewInt(0)) < 0 {
-		tmp.Neg(tmp)
-		e.Neg(e)
+	FV, err := F.Mul(secKey.V)
+	if err != nil {
+		return nil, err
 	}
+	FV = FV.Mod(bn256.Order)
+	FVvec := FV.ToVec()
+	//fmt.Println(FVvec)
 
-	return new(bn256.G2).ScalarMult(e, tmp), nil
+	yIPE := append(UTFvec, FVvec...)
+	//fmt.Println(yIPE)
+	feKey, err := q.PartFHIPE.DeriveKey(yIPE, secKey.SecIPE)
+
+	return feKey, err
 }
 
 // Decrypt decrypts the ciphertext c with the derived functional
 // encryption key key in order to obtain function x^T * F * y.
-func (q *SGP) Decrypt(c *SGPCipher, key *bn256.G2, F data.Matrix) (*big.Int, error) {
-	prod := bn256.Pair(c.G1MulGamma, key)
+func (q *Quad) Decrypt(c *QuadCipher, feKey data.VectorG2, F data.Matrix) (*big.Int, error) {
+	fmt.Println(c.CIPE, feKey)
+	d := q.PartFHIPE.PartDecrypt(c.CIPE, feKey)
 
-	for i, row := range F {
-		for j, rowEl := range row {
-			if rowEl.Sign() != 0 {
-				e1 := bn256.Pair(c.AMulG1[i][0], c.BMulG2[j][0])
-				e2 := bn256.Pair(c.AMulG1[i][1], c.BMulG2[j][1])
-				e := new(bn256.GT).Add(e1, e2)
-
-				tmp := new(big.Int).Set(rowEl)
-				if tmp.Sign() == -1 {
-					tmp.Neg(tmp)
-					e.Neg(e)
-				}
-
-				t := new(bn256.GT).ScalarMult(e, tmp)
-				prod.Add(prod, t)
-			}
-		}
+	FCy, err := F.MatMulVecG2(c.Cy)
+	if err != nil {
+		return nil, err
 	}
 
-	g1gen := new(bn256.G1).ScalarBaseMult(big.NewInt(1))
-	g2gen := new(bn256.G2).ScalarBaseMult(big.NewInt(1))
-	g := bn256.Pair(g1gen, g2gen)
+	v := new(bn256.GT).ScalarBaseMult(big.NewInt(0))
+	for i := 0; i < q.N; i++ {
+		pairedI := bn256.Pair(c.Cx[i], FCy[i])
+		v = new(bn256.GT).Add(pairedI, v)
+	}
+	d = new(bn256.GT).Neg(d)
+	v = new(bn256.GT).Add(v, d)
 
-	// b: b = n^2 * b^3
-	b3 := new(big.Int).Exp(q.Bound, big.NewInt(3), nil)
-	n2 := new(big.Int).Exp(big.NewInt(int64(q.N)), big.NewInt(2), nil)
-	b := new(big.Int).Mul(n2, b3)
+	// todo bound
+	calc := dlog.NewCalc().InBN256().WithNeg()
 
-	return q.GCalc.WithBound(b).WithNeg().BabyStepGiantStep(prod, g)
+	//fmt.Println("dec", dec, new(bn256.GT).ScalarBaseMult(big.NewInt(0)))
+	res, err := calc.BabyStepGiantStep(v, new(bn256.GT).ScalarBaseMult(big.NewInt(1)))
+
+	return res, err
 }

--- a/quadratic/quad_test.go
+++ b/quadratic/quad_test.go
@@ -33,7 +33,7 @@ func TestQuad(t *testing.T) {
 	bound := big.NewInt(100)
 	q, err := quadratic.NewQuad(n, m, bound)
 	if err != nil {
-		t.Fatalf("error when creating schmeme: %v", err)
+		t.Fatalf("error when creating scheme: %v", err)
 	}
 
 	// generate public and secret key
@@ -54,7 +54,7 @@ func TestQuad(t *testing.T) {
 		t.Fatalf("error when generating random vector: %v", err)
 	}
 
-	// simulate an encryptor that encrypt two random vectors
+	// simulate an encryptor that encrypts the two random vectors
 	encryptor := quadratic.NewQuadFromParams(q.Params)
 	c, err := encryptor.Encrypt(x, y, pubKey)
 	if err != nil {

--- a/quadratic/quad_test.go
+++ b/quadratic/quad_test.go
@@ -1,0 +1,1 @@
+package quadratic

--- a/quadratic/quad_test.go
+++ b/quadratic/quad_test.go
@@ -1,1 +1,80 @@
-package quadratic
+/*
+ * Copyright (c) 2018 XLAB d.o.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quadratic_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/fentec-project/gofe/quadratic"
+	"fmt"
+	"github.com/fentec-project/gofe/data"
+	"github.com/fentec-project/gofe/sample"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQuad(t *testing.T) {
+	bound := big.NewInt(100)
+	sampler := sample.NewUniform(bound)
+	n := 100
+	f, err := data.NewRandomMatrix(n, n, sampler)
+	if err != nil {
+		t.Fatalf("error when generating random matrix: %v", err)
+	}
+
+	q := quadratic.NewQuad(n, n, bound)
+	pubKey, secKey, err := q.GenerateKeys()
+	if err != nil {
+		t.Fatalf("error when generating keys: %v", err)
+	}
+
+
+	x, err := data.NewRandomVector(n, sampler)
+	if err != nil {
+		t.Fatalf("error when generating random vector: %v", err)
+	}
+	y, err := data.NewRandomVector(n, sampler)
+	if err != nil {
+		t.Fatalf("error when generating random vector: %v", err)
+	}
+
+
+	c, err := q.Encrypt(x, y, pubKey)
+	if err != nil {
+		t.Fatalf("error when encrypting: %v", err)
+	}
+
+	feKey, err := q.DeriveKey(secKey, f)
+	if err != nil {
+		t.Fatalf("error when deriving key: %v", err)
+	}
+
+	fmt.Println(c, feKey)
+
+	check, err := f.MulXMatY(x, y)
+	if err != nil {
+		t.Fatalf("error when computing x*F*y: %v", err)
+	}
+
+	fmt.Println(check)
+	dec, err := q.Decrypt(c, feKey, f)
+	if err != nil {
+		t.Fatalf("error when decrypting: %v", err)
+	}
+
+	assert.Equal(t, check, dec, "Decryption wrong")
+}

--- a/quadratic/sgp_test.go
+++ b/quadratic/sgp_test.go
@@ -27,9 +27,9 @@ import (
 )
 
 func TestSGP(t *testing.T) {
-	bound := big.NewInt(1000)
+	bound := big.NewInt(100)
 	sampler := sample.NewUniformRange(new(big.Int).Neg(bound), bound)
-	n := 2
+	n := 100
 	f, err := data.NewRandomMatrix(n, n, sampler)
 	if err != nil {
 		t.Fatalf("error when generating random matrix: %v", err)

--- a/quadratic/sgp_test.go
+++ b/quadratic/sgp_test.go
@@ -29,7 +29,7 @@ import (
 func TestSGP(t *testing.T) {
 	bound := big.NewInt(100)
 	sampler := sample.NewUniformRange(new(big.Int).Neg(bound), bound)
-	n := 100
+	n := 10
 	f, err := data.NewRandomMatrix(n, n, sampler)
 	if err != nil {
 		t.Fatalf("error when generating random matrix: %v", err)

--- a/sample/normal.go
+++ b/sample/normal.go
@@ -113,7 +113,7 @@ func Bernoulli(t *big.Int, lSquareInv *big.Float) (bool, error) {
 	check2 := uint64(1) << (bitLenForSample + powOfAExponent + 1 - maxExp)
 
 	// constant time check if r1 < check1 && r2 < check2
-	return (cmpMask & (r1 - check1) & (r2 - check2)) > 0 || powOfZ == 1, nil
+	return (cmpMask&(r1-check1)&(r2-check2)) > 0 || powOfZ == 1, nil
 }
 
 // precompExp precomputes the values of exp(-2^i / 2 * sigma^2) needed


### PR DESCRIPTION
This PR implements a FE public key quadratic scheme for multivariate polynomials. The scheme allows to encrypt vectors `x` and `y` using a public key and to derive a FE key corresponding to a matrix `F` so that using the FE key one can decrypt the value `x^TFy` without revealing `x` or `y`.

Additionally, a partially function hiding inner product FE scheme (partFHIPE) is implemented on which the quadratic scheme is based.  partFHIPE is a public key FE scheme that allows to encrypt vectors and produce FE keys to be able to decrypt only the inner product of the encryption and chosen vector without revealing the encrypted or FE key vector. Public key encryption allows to encrypt only vectors from a chosen subspace. This way a functional encryption key does not reveal its corresponding inner product vector. 