### PR TITLE
add check for len = 0 matForKey

### DIFF
--- a/abe/fame.go
+++ b/abe/fame.go
@@ -364,6 +364,10 @@ func (a *FAME) Decrypt(cipher *FAMECipher, key *FAMEAttribKeys, pk *FAMEPubKey) 
 	}
 
 	// get a combination alpha of keys needed to decrypt
+	// matForKey may have a len of 0 if there is a single condition
+	if len(matForKey) == 0 {
+		return "", fmt.Errorf("provided key is not sufficient for decryption")
+	}
 	oneVec := data.NewConstantVector(len(matForKey[0]), big.NewInt(0))
 	oneVec[0].SetInt64(1)
 	alpha, err := data.GaussianEliminationSolver(matForKey.Transpose(), oneVec, a.P)

--- a/abe/fame.go
+++ b/abe/fame.go
@@ -363,11 +363,12 @@ func (a *FAME) Decrypt(cipher *FAMECipher, key *FAMEAttribKeys, pk *FAMEPubKey) 
 		return "", fmt.Errorf("the provided cipher is faulty")
 	}
 
-	// get a combination alpha of keys needed to decrypt
 	// matForKey may have a len of 0 if there is a single condition
 	if len(matForKey) == 0 {
 		return "", fmt.Errorf("provided key is not sufficient for decryption")
 	}
+
+	// get a combination alpha of keys needed to decrypt
 	oneVec := data.NewConstantVector(len(matForKey[0]), big.NewInt(0))
 	oneVec[0].SetInt64(1)
 	alpha, err := data.GaussianEliminationSolver(matForKey.Transpose(), oneVec, a.P)

--- a/abe/fame_test.go
+++ b/abe/fame_test.go
@@ -90,4 +90,25 @@ func TestFAME(t *testing.T) {
 	// that has insufficient attributes
 	_, err = a.Decrypt(cipher, keysInsuff, pubKey)
 	assert.Error(t, err)
+
+	mspSingleCondition, err := abe.BooleanToMSP("0", false)
+	if err != nil {
+		t.Fatalf("Failed to generate the policy: %v", err)
+	}
+
+	// encrypt the message msg with the decryption policy specified by the
+	// msp structure
+	cipherSingleCondition, err := a.Encrypt(msg, mspSingleCondition, pubKey)
+	if err != nil {
+		t.Fatalf("Failed to encrypt: %v", err)
+	}
+
+	msgCheckSingleCondition, err := a.Decrypt(cipherSingleCondition, keys, pubKey)
+	if err != nil {
+		t.Fatalf("Failed to decrypt: %v", err)
+	}
+	assert.Equal(t, msg, msgCheckSingleCondition)
+
+	_, err = a.Decrypt(cipherSingleCondition, keysInsuff, pubKey)
+	assert.Error(t, err)
 }


### PR DESCRIPTION
Not sure if that's a valid scenario, but when using a single condition, for example, `abe.BooleanToMSP("1234", false)` gofe will crash with `panic: runtime error: index out of range [0] with length 0` on line https://github.com/fentec-project/gofe/blob/master/abe/fame.go#L367

When debugging (above policy, attribkey is 3456), attribMap will be:
```
(map[int]bool) (len=1) {
 (int) 3456: (bool) true
}
```
but RowToAttrib will be
```
([]int) (len=1 cap=1) {
 (int) 1234
}
```

This means https://github.com/fentec-project/gofe/blob/master/abe/fame.go#L353 will always be false, and `preMatForKey[countAttrib]` will not be initialized, causing the failure.

Adding a test to validate the length of the map prevents this.

Added a test with a single condition to confirm