### PR TITLE
Precomputation of small steps in dlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To make sure the library works as expected, navigate to your `$GOPATH/src/github
 directory and run `go test -v ./...` . 
 
 ## Using GoFE in your project
-After you have successfuly built the library, you can use it in your project.
+After you have successfully built the library, you can use it in your project.
 Instructions below provide a brief introduction to the most important parts
 of the library, and guide you through a sequence of steps that will quickly
 get your FE example up and running.  
@@ -81,7 +81,7 @@ attacks (IND-CPA security). You will need `SGP` scheme from package `quadratic`.
 that is based on the underlying partially function hiding inner product scheme and offers semi-adaptive
 simulation based security. You will need `quad` scheme from package `quadratic`.
 
-#### Schemes with attribute based encryption (ABE)
+#### Schemes with the attribute based encryption (ABE)
 Schemes are organized under package `abe`.
 
 It contains three ABE schemes:
@@ -101,7 +101,7 @@ some configuration, e.g. values of parameters for the selected scheme.
 
 Let's say we selected a `simple.DDH` scheme. We create a new scheme instance with:
 ````go
-scheme, _ := simple.NewDDH(5, 128, big.NewInt(1000))
+scheme, _ := simple.NewDDH(5, 1024, big.NewInt(1000))
 ````
 
 In the line above, the first argument is length of input vectors **x**
@@ -168,7 +168,18 @@ You can quickly construct random vectors and matrices by:
     X, _ := data.NewRandomMatrix(2, 3, s) // creates a random 2x3 matrix
     ````
     
-## Use the scheme (examples)
+## Use the scheme
+To see how the schemes can be used consult one of the following.
+
+#### Tests
+Every implemented scheme has an implemented test to verify the correctness
+of the implementation (for example Paillier inner-product scheme implemented in
+`innerprod/fullysec/paillier.go` has a corresponding test in 
+`innerprod/fullysec/paillier_test.go`). One can check the appropriate test
+file to see an example of how the chosen scheme can be used.
+
+#### Examples
+We give some concrete examples how to use the schemes. 
 Please note that all the examples below omit error management.
 
 ##### Using a single input scheme

--- a/internal/dlog/calc.go
+++ b/internal/dlog/calc.go
@@ -29,7 +29,7 @@ import (
 // exhaustive computation for practical purposes.
 // If Calc is configured to use a boundary value > MaxBound,
 // it will be automatically adjusted to MaxBound.
-var MaxBound = new(big.Int).Exp(big.NewInt(2), big.NewInt(50), nil)
+var MaxBound = new(big.Int).Exp(big.NewInt(2), big.NewInt(48), nil)
 
 // Calc represents a discrete logarithm calculator.
 type Calc struct{}
@@ -289,7 +289,8 @@ func (c *CalcBN256) WithNeg() *CalcBN256 {
 	}
 }
 
-// precomputes candidates for discrete logarithm
+// Precompute precomputes small steps for the discrete logarithm
+// search. The resulting precomputation table is of size 2^maxBits.
 func (c *CalcBN256) Precompute(maxBits int) error {
 	if maxBits < 2 {
 		return fmt.Errorf("maxBits should be at least 1")

--- a/internal/dlog/calc.go
+++ b/internal/dlog/calc.go
@@ -17,6 +17,7 @@
 package dlog
 
 import (
+	"crypto/sha1"
 	"fmt"
 	"math/big"
 
@@ -28,7 +29,7 @@ import (
 // exhaustive computation for practical purposes.
 // If Calc is configured to use a boundary value > MaxBound,
 // it will be automatically adjusted to MaxBound.
-var MaxBound = big.NewInt(15000000000)
+var MaxBound = new(big.Int).Exp(big.NewInt(2), big.NewInt(50), nil)
 
 // Calc represents a discrete logarithm calculator.
 type Calc struct{}
@@ -243,6 +244,7 @@ type CalcBN256 struct {
 	bound   *big.Int
 	m       *big.Int
 	Precomp map[string]*big.Int
+	precompMaxBits int
 	neg     bool
 }
 
@@ -268,6 +270,7 @@ func (c *CalcBN256) WithBound(bound *big.Int) *CalcBN256 {
 			bound:   bound,
 			m:       m,
 			Precomp: c.Precomp,
+			precompMaxBits: c.precompMaxBits,
 			neg:     c.neg,
 		}
 	}
@@ -281,25 +284,34 @@ func (c *CalcBN256) WithNeg() *CalcBN256 {
 		bound:   c.bound,
 		m:       c.m,
 		Precomp: c.Precomp,
+		precompMaxBits: c.precompMaxBits,
 		neg:     true,
 	}
 }
 
 // precomputes candidates for discrete logarithm
-func (c *CalcBN256) precompute(g *bn256.GT) {
-	one := big.NewInt(1)
+func (c *CalcBN256) Precompute(maxBits int) error {
+	if maxBits < 2 {
+		return fmt.Errorf("maxBits should be at least 1")
+	}
+	g := new(bn256.GT).ScalarBaseMult(big.NewInt(1))
 
+	one := big.NewInt(1)
+	sh := sha1.New()
 	// big.Int cannot be a key, thus we use a stringified bytes representation of the integer
 	T := make(map[string]*big.Int)
 	x := bn256.GetGTOne()
 
-	// remainders (r)
-	for i := big.NewInt(0); i.Cmp(c.m) < 0; i.Add(i, one) {
-		T[x.String()] = new(big.Int).Set(i)
+	for i := big.NewInt(0); i.BitLen() <= maxBits; i.Add(i, one) {
+		sh.Write([]byte(x.String()))
+		T[string(sh.Sum(nil)[:10])] = new(big.Int).Set(i)
+		sh.Reset()
 		x = new(bn256.GT).Add(x, g)
 	}
 
 	c.Precomp = T
+	c.precompMaxBits = maxBits
+	return nil
 }
 
 // BabyStepGiantStepStd implements the baby-step giant-step method to
@@ -315,15 +327,11 @@ func (c *CalcBN256) BabyStepGiantStepStd(h, g *bn256.GT) (*big.Int, error) {
 	one := big.NewInt(1)
 
 	// first part of the method can be reused so we
-	// precompute it and save it for later
-	if c.Precomp == nil {
-		c.precompute(g)
-	}
+	// Precompute it and save it for later
 
-	// if group is small, the list can be smaller
-	precompLen := big.NewInt(int64(len(c.Precomp)))
-	if c.m.Cmp(precompLen) != 0 {
-		c.m.Set(precompLen)
+	if c.Precomp == nil {
+		maxbits := c.m.BitLen() + 1
+		_ = c.Precompute(maxbits)
 	}
 
 	// z = g^-m
@@ -350,12 +358,13 @@ func (c *CalcBN256) BabyStepGiantStepStd(h, g *bn256.GT) (*big.Int, error) {
 func (c *CalcBN256) BabyStepGiantStep(h, g *bn256.GT) (*big.Int, error) {
 	// create goroutines calculating positive and possibly negative
 	// result if c.neg is set to true
-	retChan := make(chan *big.Int)
-	errChan := make(chan error)
-	go c.runBabyStepGiantStepIterative(h, g, retChan, errChan)
+	retChan := make(chan *big.Int, 2)
+	errChan := make(chan error, 2)
+	quit := make(chan bool, 2)
+	go c.runBabyStepGiantStepIterative(h, g, retChan, errChan, quit)
 	if c.neg {
-		gInv := new(bn256.GT).Neg(g)
-		go c.runBabyStepGiantStepIterative(h, gInv, retChan, errChan)
+		hInv := new(bn256.GT).Neg(h)
+		go c.runBabyStepGiantStepIterative(hInv, g, retChan, errChan, quit)
 	}
 
 	// catch a value when the first routine finishes
@@ -367,6 +376,9 @@ func (c *CalcBN256) BabyStepGiantStep(h, g *bn256.GT) (*big.Int, error) {
 	if c.neg && err != nil {
 		ret = <-retChan
 		err = <-errChan
+	}
+	if c.neg {
+		quit <- true
 	}
 	// if both routines give an error, return an error
 	if err != nil {
@@ -390,51 +402,91 @@ func (c *CalcBN256) BabyStepGiantStep(h, g *bn256.GT) (*big.Int, error) {
 // within the provided bound, it returns an error. In contrast to the usual
 // implementation of the method, this one proceeds iteratively, meaning that
 // smaller the solution is, faster the algorithm finishes.
-func (c *CalcBN256) runBabyStepGiantStepIterative(h, g *bn256.GT, retChan chan *big.Int, errChan chan error) {
+func (c *CalcBN256) runBabyStepGiantStepIterative(h, g *bn256.GT, retChan chan *big.Int, errChan chan error,  quit chan bool) {
 	one := big.NewInt(1)
 	two := big.NewInt(2)
 
-	// bn256.GT cannot be a key, thus we use a stringified representation of the struct
-	T := make(map[string]*big.Int)
+
+	var startBits int
+	if c.Precomp == nil {
+		_ = c.Precompute(2)
+	}
+
+	startBits = c.precompMaxBits
+
 	// prepare values for the loop
-	x := bn256.GetGTOne()
 	y := new(bn256.GT).Set(h)
-	z := new(bn256.GT).Neg(g)
-	z.ScalarMult(z, two)
-
-	bits := int64(c.m.BitLen())
-
-	T[x.String()] = big.NewInt(0)
-	x.Add(x, g)
 	j := big.NewInt(0)
+
+	// define first giant step
 	giantStep := new(big.Int)
-	bound := new(big.Int)
-	for i := int64(0); i < bits; i++ {
-		// iteratively increasing giant step up to maximal value c.m
-		giantStep.Exp(two, big.NewInt(i+1), nil)
-		if giantStep.Cmp(c.m) > 0 {
-			giantStep.Set(c.m)
-			z.Neg(g)
-			z.ScalarMult(z, c.m)
-		}
-		// for the selected giant step, add all the needed small steps
-		for k := new(big.Int).Exp(two, big.NewInt(i), nil); k.Cmp(giantStep) < 0; k.Add(k, one) {
-			T[x.String()] = new(big.Int).Set(k)
-			x.Add(x, g)
-		}
-		// make giant steps and search for the solution
-		bound.Exp(two, big.NewInt(2*(i+1)), nil)
-		for ; j.Cmp(bound) < 0; j.Add(j, giantStep) {
-			if e, ok := T[y.String()]; ok {
+	giantStep.Exp(big.NewInt(2), big.NewInt(int64(startBits)), nil)
+	z := new(bn256.GT).Neg(g)
+	z.ScalarMult(z, giantStep)
+
+	bound := new(big.Int).Exp(two, big.NewInt(2*int64(startBits)), nil)
+	sh := sha1.New()
+	for ; j.Cmp(bound) < 0; j.Add(j, giantStep) {
+		select {
+		case <-quit:
+			return
+		default:
+			sh.Write([]byte(y.String()))
+			e, ok := c.Precomp[string(sh.Sum(nil)[:10])]
+			sh.Reset()
+			if ok {
 				retChan <- new(big.Int).Add(j, e)
 				errChan <- nil
 				return
 			}
 			y.Add(y, z)
 		}
-		z.Add(z, z)
+	}
+	z.Add(z, z)
+	x := new(bn256.GT).ScalarMult(g, new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(startBits)), nil))
+
+	T := make(map[string]*big.Int)
+	for k,v := range c.Precomp {
+		T[k] = v
 	}
 
+	bits := int64(c.m.BitLen())
+	for i := int64(startBits); i < bits; i++ {
+		select {
+		case <-quit:
+			return
+		default:
+			// iteratively increasing giant step up to maximal value c.m
+			giantStep.Exp(two, big.NewInt(i+1), nil)
+			if giantStep.Cmp(c.m) > 0 {
+				giantStep.Set(c.m)
+				z.Neg(g)
+				z.ScalarMult(z, c.m)
+			}
+			// for the selected giant step, add all the needed small steps
+			for k := new(big.Int).Exp(two, big.NewInt(i), nil); k.Cmp(giantStep) < 0; k.Add(k, one) {
+				//fmt.Print("k", k, "\n")
+				sh.Write([]byte(x.String()))
+				T[string(sh.Sum(nil)[:10])] = new(big.Int).Set(k)
+				sh.Reset()
+				x = new(bn256.GT).Add(x, g)
+			}
+			// make giant steps and search for the solution
+			bound.Exp(giantStep, two, nil)
+			for ; j.Cmp(bound) < 0; j.Add(j, giantStep) {
+				sh.Write([]byte(y.String()))
+				e, ok := T[string(sh.Sum(nil)[:10])]
+				sh.Reset()
+				if ok {
+					retChan <- new(big.Int).Add(j, e)
+					errChan <- nil
+					return
+				}
+				y.Add(y, z)
+			}
+			z.Add(z, z)
+		}
+	}
 	retChan <- nil
 	errChan <- fmt.Errorf("failed to find the discrete logarithm within bound")
 }

--- a/internal/dlog/calc_test.go
+++ b/internal/dlog/calc_test.go
@@ -102,6 +102,5 @@ func TestCalcBN256_BabyStepGiantStep(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error in baby step - giant step algorithm: %v", err)
 	}
-
 	assert.Equal(t, xCheck.Cmp(x), 0, "BabyStepGiantStep in BN256 returns wrong dlog")
 }

--- a/internal/dlog/calc_test.go
+++ b/internal/dlog/calc_test.go
@@ -77,7 +77,7 @@ func TestCalcZp_BabyStepGiantStep_ElGamal(t *testing.T) {
 }
 
 func TestCalcBN256_BabyStepGiantStep(t *testing.T) {
-	bound := big.NewInt(100000000)
+	bound := big.NewInt(1000000)
 	sampler := sample.NewUniformRange(new(big.Int).Neg(bound), bound)
 
 	xCheck, err := sampler.Sample()
@@ -85,6 +85,7 @@ func TestCalcBN256_BabyStepGiantStep(t *testing.T) {
 		t.Fatalf("error when generating random number: %v", err)
 	}
 
+	//xCheck = big.NewInt(16)
 	g := new(bn256.GT).ScalarBaseMult(big.NewInt(1))
 	h := new(bn256.GT)
 	if xCheck.Sign() == 1 {
@@ -96,6 +97,7 @@ func TestCalcBN256_BabyStepGiantStep(t *testing.T) {
 	}
 
 	calc := NewCalc().InBN256().WithBound(bound).WithNeg()
+	calc.Precompute(5)
 	x, err := calc.BabyStepGiantStep(h, g)
 	if err != nil {
 		t.Fatalf("Error in baby step - giant step algorithm: %v", err)

--- a/internal/dlog/calc_test.go
+++ b/internal/dlog/calc_test.go
@@ -97,7 +97,10 @@ func TestCalcBN256_BabyStepGiantStep(t *testing.T) {
 	}
 
 	calc := NewCalc().InBN256().WithBound(bound).WithNeg()
-	calc.Precompute(5)
+	err = calc.Precompute(5)
+	if err != nil {
+		t.Fatalf("error when prcomputing: %v", err)
+	}
 	x, err := calc.BabyStepGiantStep(h, g)
 	if err != nil {
 		t.Fatalf("Error in baby step - giant step algorithm: %v", err)


### PR DESCRIPTION
This PR introduces an option to precompute a table of baby steps in Baby-step giant-step discrete logarithm algorithm of chosen size in the bn256.GT group.