### PR TITLE
RingLWE based inner-product scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ We organized implementations in two categories based on their security assumptio
 * Schemes with **selective security under chosen-plaintext 
 attacks** (s-IND-CPA security):
     * Scheme by _Abdalla, Bourse, De Caro, Pointcheval_ ([paper](https://eprint.iacr.org/2015/017.pdf)). The scheme can be instantiated from DDH (`simple.DDH`), LWE (`simple.LWE`) primitives.
-    * Experimental Ring-LWE scheme whose security will be argued in a future paper (`simple.RingLWE`)
+    * Ring-LWE scheme based on _Bermudo Mera, Karmakar, Marc, and Soleimanian_ ([paper](https://eprint.iacr.org/2021/046)), see `simple.RingLWE`.
     * Multi-input scheme based on paper by _Abdalla, Catalano, Fiore, Gay, Ursu_ ([paper](https://eprint.iacr.org/2017/972.pdf)) and instantiated from the scheme in the first point (`simple.DDHMulti`).
 
 * Schemes with stronger **adaptive security under chosen-plaintext attacks** (IND-CPA

--- a/innerprod/simple/ringlwe.go
+++ b/innerprod/simple/ringlwe.go
@@ -60,7 +60,6 @@ type RingLWEParams struct {
 // see https://eprint.iacr.org/2021/046.
 type RingLWE struct {
 	Params  *RingLWEParams
-	//Sampler *sample.NormalCumulative
 }
 
 // NewRingLWE configures a new instance of the scheme.

--- a/innerprod/simple/ringlwe.go
+++ b/innerprod/simple/ringlwe.go
@@ -17,6 +17,7 @@
 package simple
 
 import (
+	gofe "github.com/fentec-project/gofe/internal"
 	"math"
 	"math/big"
 
@@ -55,7 +56,7 @@ type RingLWEParams struct {
 // ring of polynomials R = Z[x]/((x^n)+1).
 type RingLWE struct {
 	Params  *RingLWEParams
-	Sampler *sample.NormalCumulative
+	//Sampler *sample.NormalCumulative
 }
 
 // NewRingLWE configures a new instance of the scheme.
@@ -70,7 +71,7 @@ type RingLWE struct {
 // any of these conditions is violated, or if public parameters
 // for the scheme cannot be generated for some other reason,
 // an error is returned.
-func NewRingLWE(l, n int, boundX, boundY *big.Int) (*RingLWE, error) {
+func NewRingLWE(sec, l int, boundX, boundY *big.Int) (*RingLWE, error) {
 	//// Ensure that p >= 2 * l * B² holds
 	//bSquared := new(big.Int).Mul(bound, bound)
 	//lTimesBsquared := new(big.Int).Mul(big.NewInt(int64(l)), bSquared)
@@ -78,94 +79,80 @@ func NewRingLWE(l, n int, boundX, boundY *big.Int) (*RingLWE, error) {
 	//if p.Cmp(twolTimesBsquared) < 0 {
 	//	return nil, fmt.Errorf("precondition violated: p >= 2*l*b² doesn't hold")
 	//}
-	if !isPowOf2(n) {
-		return nil, fmt.Errorf("security parameter n is not a power of 2")
-	}
+	//if !isPowOf2(n) {
+	//	return nil, fmt.Errorf("security parameter n is not a power of 2")
+	//}
 
 	K := new(big.Int).Mul(boundX, boundY)
-	K.Mul(K, big.NewInt(2))
+	K.Mul(K, big.NewInt(int64(2*l)))
 
-	kappa := big.NewFloat(80)
+	kappa := big.NewFloat(float64(sec))
 	kappaSqrt := new(big.Float).Sqrt(kappa)
 
-	sigma := big.NewFloat(20)
+	sigma := big.NewFloat(1)
 	sigma1 := new(big.Float).Mul(big.NewFloat(math.Sqrt(float64(4*l))), sigma)
 	sigma1.Mul(sigma1, new(big.Float).SetInt(boundX))
+	var q *big.Int
+	var sigma2, sigma3 *big.Float
+	var safe bool
+	var n int
+	bb := float64(sec) / 0.265
 
-	sigma2 := new(big.Float).Mul(big.NewFloat(math.Sqrt(float64(2*(l+2)*n*n))), sigma)
-	sigma2.Mul(sigma2, sigma1)
-	sigma2.Mul(sigma2, kappaSqrt)
+	for pow := 6; pow < 20; pow++ {
+		n = 1 << uint(pow)
+		//fmt.Println(n)
 
-	sigma3 := new(big.Float).Mul(sigma2, big.NewFloat(math.Sqrt(float64(2))))
+		sigma2 = new(big.Float).Mul(big.NewFloat(math.Sqrt(float64(2*(l+2)*n*n))), sigma)
+		sigma2.Mul(sigma2, sigma1)
+		sigma2.Mul(sigma2, kappaSqrt)
 
-	qFloat1 := new(big.Float).Mul(sigma1, sigma2)
-	qFloat1.Mul(qFloat1, kappa)
-	qFloat1.Mul(qFloat1, big.NewFloat(float64(2*n)))
-	qFloat2 := new(big.Float).Mul(kappaSqrt, sigma3)
-	qFloat := new(big.Float).Add(qFloat1, qFloat2)
-	qFloat.Mul(qFloat,  new(big.Float).SetInt(boundY))
-	qFloat.Mul(qFloat,  big.NewFloat(float64(l)))
+		sigma3 = new(big.Float).Mul(sigma2, big.NewFloat(math.Sqrt(float64(2))))
 
-	q, _ := qFloat.Int(nil)
+		qFloat1 := new(big.Float).Mul(sigma1, sigma2)
+		qFloat1.Mul(qFloat1, kappa)
+		qFloat1.Mul(qFloat1, big.NewFloat(float64(2*n)))
+		qFloat2 := new(big.Float).Mul(kappaSqrt, sigma3)
+		qFloat := new(big.Float).Add(qFloat1, qFloat2)
+		qFloat.Mul(qFloat, new(big.Float).SetInt(boundY))
+		qFloat.Mul(qFloat, big.NewFloat(float64(2*l)))
 
 
-	qF := new(big.Float).SetInt(q)
-	qFF, _ := qF.Float64()
-	//safe := true
-	sigmaPrimeQF, _ := sigma.Float64()
+		q, _ = qFloat.Int(nil)
+		q.Mul(q, K)
 
-	fmt.Println("here")
-	//fmt.Println(q.BitLen(), math.Log2(sigmaPrimeQF))
+		qF := new(big.Float).SetInt(q)
+		qFF, _ := qF.Float64()
+		//safe := true
+		sigmaPrimeQF, _ := sigma.Float64()
 
-	cost := 100000000000000000000000000000000.0
-	for b := float64(50); b < float64(3*n + 1); b = b + 1 {
-		//if .265 * b > cost{
-		//	break
-		//}
-		for m := int(math.Max(1, b-float64(n))); m < 3*n; m++ {
-			//m = 2525
-			//b = 296
-			primalCost := float64(b) * 0.256
-			delta := math.Pow(math.Pow(math.Pi * b, 1 / b) * b / (2 * math.Pi * math.E), 1. / (2. * b - 2.))
-			//fmt.Println(b, delta)
-			left := sigmaPrimeQF * math.Sqrt(b)
-			d := n + m
-			right := math.Pow(delta, 2 * b - float64(d) - 1) * math.Pow(qFF, float64(m) / float64(d))
-			//fmt.Println(left, right)
+		safe = true
+		//cost := 100000000000000000000000000000000.0
 
-			if left < right {
-				//fmt.Print("Found")
-				cost = math.Min(cost, primalCost)
-				//fmt.Println(left, right)
-				//fmt.Println(b, m, primalCost)
+		for b := float64(50); b <= bb; b = b + 1 {
+			for m := int(math.Max(1, b-float64(n))); m < 3*n; m++ {
+				delta := math.Pow(math.Pow(math.Pi*b, 1/b)*b/(2*math.Pi*math.E), 1./(2.*b-2.))
+				left := sigmaPrimeQF * math.Sqrt(b)
+				d := n + m
+				right := math.Pow(delta, 2*b-float64(d)-1) * math.Pow(qFF, float64(m)/float64(d))
+				//primalCost := float64(b) * 0.256
+				if left < right {
+					//cost = math.Min(cost, primalCost)
+					//fmt.Println("b", b, primalCost)
+
+					safe = false
+					break
+				}
 			}
-			//break
+			if safe == false {
+				break
+			}
 		}
-		//break
+		if safe {
+			break
+		}
 	}
 
-	fmt.Println(q, q.BitLen(), n, sigma1, sigma2, sigma3, cost)
-	//delta := math.Pow(math.Pow(math.Pi * b, 1 / b) * b / (2 * math.Pi * math.E), 1. / (2. * b - 2.))
-	//
-	//
-	//for mForTest := n; mForTest < 2*n; mForTest++ {
-	//	d := n + mForTest
-	//	left := sigmaPrimeQF * math.Sqrt(b)
-	//	right := math.Pow(delta, 2 * b - float64(d) - 1) * math.Pow(qFF, float64(mForTest) / float64(d))
-	//	if left < right {
-	//		fmt.Println(mForTest)
-	//		safe = false
-	//		break
-	//	}
-	//}
-	//if safe {
-	//	break
-	//}
-
-
-
-
-
+	fmt.Println(q, q.BitLen(), n, sigma1, sigma2, sigma3)
 
 	randVec, err := data.NewRandomVector(n, sample.NewUniform(q))
 	if err != nil {
@@ -185,184 +172,191 @@ func NewRingLWE(l, n int, boundX, boundY *big.Int) (*RingLWE, error) {
 			Sigma3: sigma3,
 			A:     randVec,
 		},
-		Sampler: sample.NewNormalCumulative(sigma, uint(n), true),
 	}, nil
 }
-//
-//// Calculates the center function t(x) = floor(x*q/p) % q for a matrix X.
-//func (s *RingLWE) center(X data.Matrix) data.Matrix {
-//	return X.Apply(func(x *big.Int) *big.Int {
-//		t := new(big.Int)
-//		t.Mul(x, s.Params.Q)
-//		t.Div(t, s.Params.P)
-//		t.Mod(t, s.Params.Q)
-//
-//		return t
-//	})
-//}
-//
-//// GenerateSecretKey generates a secret key for the scheme.
-//// The key is a matrix of l*n small elements sampled from
-//// Discrete Gaussian distribution.
-////
-//// In case secret key could not be generated, it returns an error.
-//func (s *RingLWE) GenerateSecretKey() (data.Matrix, error) {
-//	return data.NewRandomMatrix(s.Params.L, s.Params.N, s.Sampler)
-//}
-//
-//// GeneratePublicKey accepts a master secret key SK and generates a
-//// corresponding master public key.
-//// Public key is a matrix of l*n elements.
-//// In case of a malformed secret key the function returns an error.
-//func (s *RingLWE) GeneratePublicKey(SK data.Matrix) (data.Matrix, error) {
-//	if !SK.CheckDims(s.Params.L, s.Params.N) {
-//		return nil, gofe.ErrMalformedPubKey
-//	}
-//	// Generate noise matrix
-//	// Elements are sampled from the same distribution as the secret key S.
-//	E, err := data.NewRandomMatrix(s.Params.L, s.Params.N, s.Sampler)
-//	if err != nil {
-//		return nil, errors.Wrap(err, "public key generation failed")
-//	}
-//
-//	// Calculate public key PK row by row as PKi = (a * SKi + Ei) % q.
-//	// Multiplication and addition are in the ring of polynomials
-//	PK := make(data.Matrix, s.Params.L)
-//	for i := 0; i < PK.Rows(); i++ {
-//		pkI, _ := SK[i].MulAsPolyInRing(s.Params.A)
-//		pkI = pkI.Add(E[i])
-//		PK[i] = pkI
-//	}
-//	PK = PK.Mod(s.Params.Q)
-//
-//	return PK, nil
-//}
-//
-//// DeriveKey accepts input vector y and master secret key SK, and derives a
-//// functional encryption key.
-//// In case of malformed secret key or input vector that violates the
-//// configured bound, it returns an error.
-//func (s *RingLWE) DeriveKey(y data.Vector, SK data.Matrix) (data.Vector, error) {
-//	if err := y.CheckBound(s.Params.Bound); err != nil {
-//		return nil, err
-//	}
-//	if !SK.CheckDims(s.Params.L, s.Params.N) {
-//		return nil, gofe.ErrMalformedSecKey
-//	}
-//	// Secret key is a linear combination of input vector y and master secret keys.
-//	SKTrans := SK.Transpose()
-//	skY, err := SKTrans.MulVec(y)
-//	if err != nil {
-//		return nil, gofe.ErrMalformedInput
-//	}
-//	skY = skY.Mod(s.Params.Q)
-//
-//	return skY, nil
-//}
-//
-//// Encrypt encrypts matrix X using public key PK.
-//// It returns the resulting ciphertext matrix. In case of malformed
-//// public key or input matrix that violates the configured bound,
-//// it returns an error.
-////
-////The resulting ciphertext has dimensions (l + 1) * n.
-//func (s *RingLWE) Encrypt(X data.Matrix, PK data.Matrix) (data.Matrix, error) {
-//	if err := X.CheckBound(s.Params.Bound); err != nil {
-//		return nil, err
-//	}
-//
-//	if !PK.CheckDims(s.Params.L, s.Params.N) {
-//		return nil, gofe.ErrMalformedPubKey
-//	}
-//	if !X.CheckDims(s.Params.L, s.Params.N) {
-//		return nil, gofe.ErrMalformedInput
-//	}
-//
-//	// Create a small random vector r
-//	r, err := data.NewRandomVector(s.Params.N, s.Sampler)
-//	if err != nil {
-//		return nil, errors.Wrap(err, "error in encrypt")
-//	}
-//	// Create noise matrix E to secure the encryption
-//	E, err := data.NewRandomMatrix(s.Params.L, s.Params.N, s.Sampler)
-//	if err != nil {
-//		return nil, errors.Wrap(err, "error in encrypt")
-//	}
-//	// Calculate cipher CT row by row as CTi = (PKi * r + Ei) % q.
-//	// Multiplication and addition are in the ring of polynomials.
-//	CT0 := make(data.Matrix, s.Params.L)
-//	for i := 0; i < CT0.Rows(); i++ {
-//		CT0i, _ := PK[i].MulAsPolyInRing(r)
-//		CT0i = CT0i.Add(E[i])
-//		CT0[i] = CT0i
-//	}
-//	CT0 = CT0.Mod(s.Params.Q)
-//
-//	// Include the message X in the encryption
-//	T := s.center(X)
-//	CT0, _ = CT0.Add(T)
-//	CT0 = CT0.Mod(s.Params.Q)
-//
-//	// Construct the last row of the cipher
-//	ct1, _ := s.Params.A.MulAsPolyInRing(r)
-//	e, err := data.NewRandomVector(s.Params.N, s.Sampler)
-//	if err != nil {
-//		return nil, errors.Wrap(err, "error in encrypt")
-//	}
-//	ct1 = ct1.Add(e)
-//	ct1 = ct1.Mod(s.Params.Q)
-//
-//	return append(CT0, ct1), nil
-//}
-//
-//// Decrypt accepts an encrypted matrix CT, secret key skY, and plaintext
-//// vector y, and returns a vector of inner products of X's rows and y.
-//// If decryption failed (for instance with input data that violates the
-//// configured bound or malformed ciphertext or keys), error is returned.
-//func (s *RingLWE) Decrypt(CT data.Matrix, skY, y data.Vector) (data.Vector, error) {
-//	if err := y.CheckBound(s.Params.Bound); err != nil {
-//		return nil, err
-//	}
-//	if len(skY) != s.Params.N {
-//		return nil, gofe.ErrMalformedDecKey
-//	}
-//	if len(y) != s.Params.L {
-//		return nil, gofe.ErrMalformedInput
-//	}
-//
-//	if !CT.CheckDims(s.Params.L+1, s.Params.N) {
-//		return nil, gofe.ErrMalformedCipher
-//	}
-//	CT0 := CT[:s.Params.L] // First l rows of cipher
-//	ct1 := CT[s.Params.L]  // Last row of cipher
-//
-//	CT0Trans := CT0.Transpose()
-//	CT0TransMulY, _ := CT0Trans.MulVec(y)
-//	CT0TransMulY = CT0TransMulY.Mod(s.Params.Q)
-//
-//	ct1MulSkY, _ := ct1.MulAsPolyInRing(skY)
-//	ct1MulSkY = ct1MulSkY.Apply(func(x *big.Int) *big.Int {
-//		return new(big.Int).Neg(x)
-//	})
-//
-//	d := CT0TransMulY.Add(ct1MulSkY)
-//	d = d.Mod(s.Params.Q)
-//	halfQ := new(big.Int).Div(s.Params.Q, big.NewInt(2))
-//
-//	d = d.Apply(func(x *big.Int) *big.Int {
-//		if x.Cmp(halfQ) == 1 {
-//			x.Sub(x, s.Params.Q)
-//		}
-//		x.Mul(x, s.Params.P)
-//		x.Add(x, halfQ)
-//		x.Div(x, s.Params.Q)
-//
-//		return x
-//	})
-//
-//	return d, nil
-//}
 
-func isPowOf2(x int) bool {
-	return x&(x-1) == 0
+// Calculates the center function t(x) = floor(x*q/p) % q for a matrix X.
+func (s *RingLWE) center(X data.Matrix) data.Matrix {
+	return X.Apply(func(x *big.Int) *big.Int {
+		t := new(big.Int)
+		t.Mul(x, s.Params.Q)
+		t.Div(t, s.Params.P)
+		t.Mod(t, s.Params.Q)
+
+		return t
+	})
+}
+
+// GenerateSecretKey generates a secret key for the scheme.
+// The key is a matrix of l*n small elements sampled from
+// Discrete Gaussian distribution.
+//
+// In case secret key could not be generated, it returns an error.
+func (s *RingLWE) GenerateSecretKey() (data.Matrix, error) {
+	lSigmaF := new(big.Float).Quo(s.Params.Sigma1, sample.SigmaCDT)
+	lSigma, _ := lSigmaF.Int(nil)
+	sampler := sample.NewNormalDoubleConstant(lSigma)
+	return data.NewRandomMatrix(s.Params.L, s.Params.N, sampler)
+}
+
+// GeneratePublicKey accepts a master secret key SK and generates a
+// corresponding master public key.
+// Public key is a matrix of l*n elements.
+// In case of a malformed secret key the function returns an error.
+func (s *RingLWE) GeneratePublicKey(SK data.Matrix) (data.Matrix, error) {
+	if !SK.CheckDims(s.Params.L, s.Params.N) {
+		return nil, gofe.ErrMalformedPubKey
+	}
+	// Generate noise matrix
+	// Elements are sampled from the same distribution as the secret key S.
+	lSigmaF := new(big.Float).Quo(s.Params.Sigma1, sample.SigmaCDT)
+	lSigma, _ := lSigmaF.Int(nil)
+	sampler := sample.NewNormalDoubleConstant(lSigma)
+	E, err := data.NewRandomMatrix(s.Params.L, s.Params.N, sampler)
+	if err != nil {
+		return nil, errors.Wrap(err, "public key generation failed")
+	}
+
+	// Calculate public key PK row by row as PKi = (a * SKi + Ei) % q.
+	// Multiplication and addition are in the ring of polynomials
+	PK := make(data.Matrix, s.Params.L)
+	for i := 0; i < PK.Rows(); i++ {
+		pkI, _ := SK[i].MulAsPolyInRing(s.Params.A)
+		pkI = pkI.Add(E[i])
+		PK[i] = pkI
+	}
+	PK = PK.Mod(s.Params.Q)
+
+	return PK, nil
+}
+
+// DeriveKey accepts input vector y and master secret key SK, and derives a
+// functional encryption key.
+// In case of malformed secret key or input vector that violates the
+// configured bound, it returns an error.
+func (s *RingLWE) DeriveKey(y data.Vector, SK data.Matrix) (data.Vector, error) {
+	if err := y.CheckBound(s.Params.BoundY); err != nil {
+		return nil, err
+	}
+	if !SK.CheckDims(s.Params.L, s.Params.N) {
+		return nil, gofe.ErrMalformedSecKey
+	}
+	// Secret key is a linear combination of input vector y and master secret keys.
+	SKTrans := SK.Transpose()
+	skY, err := SKTrans.MulVec(y)
+	if err != nil {
+		return nil, gofe.ErrMalformedInput
+	}
+	skY = skY.Mod(s.Params.Q)
+
+	return skY, nil
+}
+
+// Encrypt encrypts matrix X using public key PK.
+// It returns the resulting ciphertext matrix. In case of malformed
+// public key or input matrix that violates the configured bound,
+// it returns an error.
+//
+//The resulting ciphertext has dimensions (l + 1) * n.
+func (s *RingLWE) Encrypt(X data.Matrix, PK data.Matrix) (data.Matrix, error) {
+	if err := X.CheckBound(s.Params.BoundX); err != nil {
+		return nil, err
+	}
+
+	if !PK.CheckDims(s.Params.L, s.Params.N) {
+		return nil, gofe.ErrMalformedPubKey
+	}
+	if !X.CheckDims(s.Params.L, s.Params.N) {
+		return nil, gofe.ErrMalformedInput
+	}
+
+	// Create a small random vector r
+	lSigma2F := new(big.Float).Quo(s.Params.Sigma2, sample.SigmaCDT)
+	lSigma2, _ := lSigma2F.Int(nil)
+	sampler2 := sample.NewNormalDoubleConstant(lSigma2)
+	r, err := data.NewRandomVector(s.Params.N, sampler2)
+	if err != nil {
+		return nil, errors.Wrap(err, "error in encrypt")
+	}
+	// Create noise matrix E to secure the encryption
+	lSigma3F := new(big.Float).Quo(s.Params.Sigma3, sample.SigmaCDT)
+	lSigma3, _ := lSigma3F.Int(nil)
+	sampler3 := sample.NewNormalDoubleConstant(lSigma3)
+	E, err := data.NewRandomMatrix(s.Params.L, s.Params.N, sampler3)
+	if err != nil {
+		return nil, errors.Wrap(err, "error in encrypt")
+	}
+	// Calculate cipher CT row by row as CTi = (PKi * r + Ei) % q.
+	// Multiplication and addition are in the ring of polynomials.
+	CT0 := make(data.Matrix, s.Params.L)
+	for i := 0; i < CT0.Rows(); i++ {
+		CT0i, _ := PK[i].MulAsPolyInRing(r)
+		CT0i = CT0i.Add(E[i])
+		CT0[i] = CT0i
+	}
+	CT0 = CT0.Mod(s.Params.Q)
+
+	// Include the message X in the encryption
+	T := s.center(X)
+	CT0, _ = CT0.Add(T)
+	CT0 = CT0.Mod(s.Params.Q)
+
+	// Construct the last row of the cipher
+	ct1, _ := s.Params.A.MulAsPolyInRing(r)
+	e, err := data.NewRandomVector(s.Params.N, sampler2)
+	if err != nil {
+		return nil, errors.Wrap(err, "error in encrypt")
+	}
+	ct1 = ct1.Add(e)
+	ct1 = ct1.Mod(s.Params.Q)
+
+	return append(CT0, ct1), nil
+}
+
+// Decrypt accepts an encrypted matrix CT, secret key skY, and plaintext
+// vector y, and returns a vector of inner products of X's rows and y.
+// If decryption failed (for instance with input data that violates the
+// configured bound or malformed ciphertext or keys), error is returned.
+func (s *RingLWE) Decrypt(CT data.Matrix, skY, y data.Vector) (data.Vector, error) {
+	if err := y.CheckBound(s.Params.BoundY); err != nil {
+		return nil, err
+	}
+	if len(skY) != s.Params.N {
+		return nil, gofe.ErrMalformedDecKey
+	}
+	if len(y) != s.Params.L {
+		return nil, gofe.ErrMalformedInput
+	}
+
+	if !CT.CheckDims(s.Params.L+1, s.Params.N) {
+		return nil, gofe.ErrMalformedCipher
+	}
+	CT0 := CT[:s.Params.L] // First l rows of cipher
+	ct1 := CT[s.Params.L]  // Last row of cipher
+
+	CT0Trans := CT0.Transpose()
+	CT0TransMulY, _ := CT0Trans.MulVec(y)
+	CT0TransMulY = CT0TransMulY.Mod(s.Params.Q)
+
+	ct1MulSkY, _ := ct1.MulAsPolyInRing(skY)
+	ct1MulSkY = ct1MulSkY.Apply(func(x *big.Int) *big.Int {
+		return new(big.Int).Neg(x)
+	})
+
+	d := CT0TransMulY.Add(ct1MulSkY)
+	d = d.Mod(s.Params.Q)
+	halfQ := new(big.Int).Div(s.Params.Q, big.NewInt(2))
+
+	d = d.Apply(func(x *big.Int) *big.Int {
+		if x.Cmp(halfQ) == 1 {
+			x.Sub(x, s.Params.Q)
+		}
+		x.Mul(x, s.Params.P)
+		x.Add(x, halfQ)
+		x.Div(x, s.Params.Q)
+
+		return x
+	})
+
+	return d, nil
 }

--- a/innerprod/simple/ringlwe.go
+++ b/innerprod/simple/ringlwe.go
@@ -21,8 +21,6 @@ import (
 	"math"
 	"math/big"
 
-	"fmt"
-
 	"github.com/fentec-project/gofe/data"
 	"github.com/fentec-project/gofe/sample"
 	"github.com/pkg/errors"
@@ -41,9 +39,9 @@ type RingLWEParams struct {
 	Sigma3 *big.Float // standard deviation
 
 	BoundX *big.Int // upper bound for coordinates of input vectors
-	BoundY *big.Int // upper bound for coordinates of input vectors
+	BoundY *big.Int // upper bound for coordinates of inner-product vectors
 
-	P *big.Int // modulus for the resulting inner product
+	P *big.Int // bound for the resulting inner product
 	Q *big.Int // modulus for ciphertext and keys
 
 	// A is a vector with N coordinates.
@@ -51,38 +49,28 @@ type RingLWEParams struct {
 	A data.Vector
 }
 
-// RingLWE represents a scheme instantiated from the LWE problem,
-// that is much more efficient than the LWE scheme. It operates in the
-// ring of polynomials R = Z[x]/((x^n)+1).
+// RingLWE represents a FE scheme instantiated from the ringLWE assumption. It
+// allows to encrypt a matrix X and derive a FE based on a vector y, so that
+// one can decrypt y^T * X and nothing else. This can be seen as a SIMD version
+// of a simple inner product scheme, since multiple vectors (columns of X) can be
+// multiplied with y at the same time.
+// It is based on
+// Bermudo Mera, Karmakar, Marc, and Soleimanian:
+// "Efficient Lattice-Based Inner-Product Functional Encryption",
+// see https://eprint.iacr.org/2021/046.
 type RingLWE struct {
 	Params  *RingLWEParams
 	//Sampler *sample.NormalCumulative
 }
 
 // NewRingLWE configures a new instance of the scheme.
-// It accepts the length of input vectors l, the main security parameter
-// n, upper bound for coordinates of input vectors x and y, modulus for the
-// inner product p, modulus for ciphertext and keys q, and parameters
-// for the sampler: standard deviation sigma, precision eps and a limit
-// k for the sampling interval.
-//
-// Note that the security parameter n must be a power of 2.
-// In addition, modulus p must be strictly smaller than l*bound². If
-// any of these conditions is violated, or if public parameters
-// for the scheme cannot be generated for some other reason,
-// an error is returned.
+// It accepts a security parameter sec, the length of input vectors l,
+// bound for coordinates of input vectors x and y. It generates all the
+// parameters needed to have a scheme with at least sec bits of security
+// by using all the bounds derived in the paper https://eprint.iacr.org/2021/046,
+// as well as having the parameters secure against so called primal attack
+// on LWE.
 func NewRingLWE(sec, l int, boundX, boundY *big.Int) (*RingLWE, error) {
-	//// Ensure that p >= 2 * l * B² holds
-	//bSquared := new(big.Int).Mul(bound, bound)
-	//lTimesBsquared := new(big.Int).Mul(big.NewInt(int64(l)), bSquared)
-	//twolTimesBsquared := new(big.Int).Mul(big.NewInt(2), lTimesBsquared)
-	//if p.Cmp(twolTimesBsquared) < 0 {
-	//	return nil, fmt.Errorf("precondition violated: p >= 2*l*b² doesn't hold")
-	//}
-	//if !isPowOf2(n) {
-	//	return nil, fmt.Errorf("security parameter n is not a power of 2")
-	//}
-
 	K := new(big.Int).Mul(boundX, boundY)
 	K.Mul(K, big.NewInt(int64(2*l)))
 
@@ -96,11 +84,9 @@ func NewRingLWE(sec, l int, boundX, boundY *big.Int) (*RingLWE, error) {
 	var sigma2, sigma3 *big.Float
 	var safe bool
 	var n int
-	bb := float64(sec) / 0.265
-
+	boundOfB := float64(sec) / 0.265
 	for pow := 6; pow < 20; pow++ {
 		n = 1 << uint(pow)
-		//fmt.Println(n)
 
 		sigma2 = new(big.Float).Mul(big.NewFloat(math.Sqrt(float64(2*(l+2)*n*n))), sigma)
 		sigma2.Mul(sigma2, sigma1)
@@ -116,29 +102,21 @@ func NewRingLWE(sec, l int, boundX, boundY *big.Int) (*RingLWE, error) {
 		qFloat.Mul(qFloat, new(big.Float).SetInt(boundY))
 		qFloat.Mul(qFloat, big.NewFloat(float64(2*l)))
 
-
 		q, _ = qFloat.Int(nil)
 		q.Mul(q, K)
 
 		qF := new(big.Float).SetInt(q)
 		qFF, _ := qF.Float64()
-		//safe := true
 		sigmaPrimeQF, _ := sigma.Float64()
 
 		safe = true
-		//cost := 100000000000000000000000000000000.0
-
-		for b := float64(50); b <= bb; b = b + 1 {
+		for b := float64(50); b <= boundOfB; b = b + 1 {
 			for m := int(math.Max(1, b-float64(n))); m < 3*n; m++ {
 				delta := math.Pow(math.Pow(math.Pi*b, 1/b)*b/(2*math.Pi*math.E), 1./(2.*b-2.))
 				left := sigmaPrimeQF * math.Sqrt(b)
 				d := n + m
 				right := math.Pow(delta, 2*b-float64(d)-1) * math.Pow(qFF, float64(m)/float64(d))
-				//primalCost := float64(b) * 0.256
 				if left < right {
-					//cost = math.Min(cost, primalCost)
-					//fmt.Println("b", b, primalCost)
-
 					safe = false
 					break
 				}
@@ -151,8 +129,6 @@ func NewRingLWE(sec, l int, boundX, boundY *big.Int) (*RingLWE, error) {
 			break
 		}
 	}
-
-	fmt.Println(q, q.BitLen(), n, sigma1, sigma2, sigma3)
 
 	randVec, err := data.NewRandomVector(n, sample.NewUniform(q))
 	if err != nil {
@@ -173,18 +149,6 @@ func NewRingLWE(sec, l int, boundX, boundY *big.Int) (*RingLWE, error) {
 			A:     randVec,
 		},
 	}, nil
-}
-
-// Calculates the center function t(x) = floor(x*q/p) % q for a matrix X.
-func (s *RingLWE) center(X data.Matrix) data.Matrix {
-	return X.Apply(func(x *big.Int) *big.Int {
-		t := new(big.Int)
-		t.Mul(x, s.Params.Q)
-		t.Div(t, s.Params.P)
-		t.Mod(t, s.Params.Q)
-
-		return t
-	})
 }
 
 // GenerateSecretKey generates a secret key for the scheme.
@@ -252,13 +216,36 @@ func (s *RingLWE) DeriveKey(y data.Vector, SK data.Matrix) (data.Vector, error) 
 	return skY, nil
 }
 
+// Calculates the center function t(x) = floor(x*q/p) % q for a matrix X and
+// place it in a bigger matrix.
+func (s *RingLWE) center(X data.Matrix) data.Matrix {
+	ret := data.NewConstantMatrix(s.Params.L, s.Params.N, big.NewInt(0))
+
+	for i := 0; i < X.Rows(); i++ {
+		for j := 0; j < X.Cols(); j++ {
+			ret[i][j].Mul(X[i][j], s.Params.Q)
+			ret[i][j].Div(ret[i][j], s.Params.P)
+			ret[i][j].Mod(ret[i][j], s.Params.Q)
+		}
+	}
+
+	return ret
+}
+
+// RingLWECipher is functional encryption key for DDH Scheme.
+type RingLWECipher struct {
+	Ct0   data.Matrix
+	Ct1   data.Vector
+	K    int
+}
+
 // Encrypt encrypts matrix X using public key PK.
 // It returns the resulting ciphertext matrix. In case of malformed
 // public key or input matrix that violates the configured bound,
 // it returns an error.
 //
 //The resulting ciphertext has dimensions (l + 1) * n.
-func (s *RingLWE) Encrypt(X data.Matrix, PK data.Matrix) (data.Matrix, error) {
+func (s *RingLWE) Encrypt(X data.Matrix, PK data.Matrix) (*RingLWECipher, error) {
 	if err := X.CheckBound(s.Params.BoundX); err != nil {
 		return nil, err
 	}
@@ -266,7 +253,7 @@ func (s *RingLWE) Encrypt(X data.Matrix, PK data.Matrix) (data.Matrix, error) {
 	if !PK.CheckDims(s.Params.L, s.Params.N) {
 		return nil, gofe.ErrMalformedPubKey
 	}
-	if !X.CheckDims(s.Params.L, s.Params.N) {
+	if !(X.Rows() == s.Params.L && X.Cols() <= s.Params.N) {
 		return nil, gofe.ErrMalformedInput
 	}
 
@@ -310,14 +297,16 @@ func (s *RingLWE) Encrypt(X data.Matrix, PK data.Matrix) (data.Matrix, error) {
 	ct1 = ct1.Add(e)
 	ct1 = ct1.Mod(s.Params.Q)
 
-	return append(CT0, ct1), nil
+	res := &RingLWECipher{Ct0: CT0, Ct1: ct1, K: X.Cols()}
+
+	return res, nil
 }
 
-// Decrypt accepts an encrypted matrix CT, secret key skY, and plaintext
+// Decrypt accepts a ciphertext CT, secret key skY, and plaintext
 // vector y, and returns a vector of inner products of X's rows and y.
 // If decryption failed (for instance with input data that violates the
 // configured bound or malformed ciphertext or keys), error is returned.
-func (s *RingLWE) Decrypt(CT data.Matrix, skY, y data.Vector) (data.Vector, error) {
+func (s *RingLWE) Decrypt(CT *RingLWECipher, skY, y data.Vector) (data.Vector, error) {
 	if err := y.CheckBound(s.Params.BoundY); err != nil {
 		return nil, err
 	}
@@ -328,11 +317,11 @@ func (s *RingLWE) Decrypt(CT data.Matrix, skY, y data.Vector) (data.Vector, erro
 		return nil, gofe.ErrMalformedInput
 	}
 
-	if !CT.CheckDims(s.Params.L+1, s.Params.N) {
+	if !CT.Ct0.CheckDims(s.Params.L, s.Params.N) || len(CT.Ct1) != s.Params.N {
 		return nil, gofe.ErrMalformedCipher
 	}
-	CT0 := CT[:s.Params.L] // First l rows of cipher
-	ct1 := CT[s.Params.L]  // Last row of cipher
+	CT0 := CT.Ct0
+	ct1 := CT.Ct1
 
 	CT0Trans := CT0.Transpose()
 	CT0TransMulY, _ := CT0Trans.MulVec(y)
@@ -358,5 +347,5 @@ func (s *RingLWE) Decrypt(CT data.Matrix, skY, y data.Vector) (data.Vector, erro
 		return x
 	})
 
-	return d, nil
+	return d[:CT.K], nil
 }

--- a/innerprod/simple/ringlwe_test.go
+++ b/innerprod/simple/ringlwe_test.go
@@ -17,65 +17,66 @@
 package simple_test
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
 
-	"github.com/fentec-project/gofe/data"
 	"github.com/fentec-project/gofe/innerprod/simple"
-	"github.com/fentec-project/gofe/sample"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSimple_RingLWE(t *testing.T) {
-	l := 100
-	n := 256
-	b := big.NewInt(1000000)
-	p, _ := new(big.Int).SetString("10000000000000000", 10)
-	q, _ := new(big.Int).SetString("903468688179973616387830299599", 10)
+	l := 64
+	n := 2048
+	bx := big.NewInt(2)
+	by := big.NewInt(2)
+	//p, _ := new(big.Int).SetString("10000000000000000", 10)
+	//q, _ := new(big.Int).SetString("903468688179973616387830299599", 10)
 
-	sigma := big.NewFloat(20)
+	//sigma := big.NewFloat(20)
+	//
+	//sampler := sample.NewUniformRange(new(big.Int).Neg(b), b)
+	//y, _ := data.NewRandomVector(l, sampler)
+	//X, _ := data.NewRandomMatrix(l, n, sampler)
+	//xy, _ := X.Transpose().MulVec(y)
+	//emptyVec := data.Vector{}
+	//emptyMat := data.Matrix{}
 
-	sampler := sample.NewUniformRange(new(big.Int).Neg(b), b)
-	y, _ := data.NewRandomVector(l, sampler)
-	X, _ := data.NewRandomMatrix(l, n, sampler)
-	xy, _ := X.Transpose().MulVec(y)
-	emptyVec := data.Vector{}
-	emptyMat := data.Matrix{}
-
-	_, err := simple.NewRingLWE(l, 24, b, p, q, sigma)
-	assert.Error(t, err) // n not a power of 2
-	_, err = simple.NewRingLWE(l, n, b, big.NewInt(10), q, sigma)
-	assert.Error(t, err) // precondition failed
-	ringLWE, err := simple.NewRingLWE(l, n, b, p, q, sigma)
+	//_, err := simple.NewRingLWE(l, 24, b, p, q, sigma)
+	//assert.Error(t, err) // n not a power of 2
+	//_, err = simple.NewRingLWE(l, n, b, big.NewInt(10), q, sigma)
+	//assert.Error(t, err) // precondition failed
+	ringLWE, err := simple.NewRingLWE(l, n, bx, by)
 	assert.NoError(t, err)
-
-	SK, err := ringLWE.GenerateSecretKey()
-	assert.NoError(t, err)
-
-	_, err = ringLWE.GeneratePublicKey(emptyMat)
-	assert.Error(t, err)
-	PK, err := ringLWE.GeneratePublicKey(SK)
-	assert.NoError(t, err)
-
-	_, err = ringLWE.DeriveKey(emptyVec, SK)
-	assert.Error(t, err)
-	_, err = ringLWE.DeriveKey(y, emptyMat)
-	assert.Error(t, err)
-	_, err = ringLWE.DeriveKey(y.MulScalar(b), SK)
-	assert.Error(t, err) // boundary violated
-	skY, err := ringLWE.DeriveKey(y, SK)
-	assert.NoError(t, err)
-
-	_, err = ringLWE.Encrypt(emptyMat, PK)
-	assert.Error(t, err)
-	_, err = ringLWE.Encrypt(X, emptyMat)
-	assert.Error(t, err)
-	_, err = ringLWE.Encrypt(X.MulScalar(b), PK)
-	assert.Error(t, err) // boundary violated
-	cipher, err := ringLWE.Encrypt(X, PK)
-	assert.NoError(t, err)
-
-	xyDecrypted, err := ringLWE.Decrypt(cipher, skY, y)
-	assert.NoError(t, err)
-	assert.Equal(t, xy, xyDecrypted, "obtained incorrect inner product")
+	fmt.Print(ringLWE)
+	//
+	//SK, err := ringLWE.GenerateSecretKey()
+	//assert.NoError(t, err)
+	//
+	//_, err = ringLWE.GeneratePublicKey(emptyMat)
+	//assert.Error(t, err)
+	//PK, err := ringLWE.GeneratePublicKey(SK)
+	//assert.NoError(t, err)
+	//
+	//_, err = ringLWE.DeriveKey(emptyVec, SK)
+	//assert.Error(t, err)
+	//_, err = ringLWE.DeriveKey(y, emptyMat)
+	//assert.Error(t, err)
+	//_, err = ringLWE.DeriveKey(y.MulScalar(b), SK)
+	//assert.Error(t, err) // boundary violated
+	//skY, err := ringLWE.DeriveKey(y, SK)
+	//assert.NoError(t, err)
+	//
+	//_, err = ringLWE.Encrypt(emptyMat, PK)
+	//assert.Error(t, err)
+	//_, err = ringLWE.Encrypt(X, emptyMat)
+	//assert.Error(t, err)
+	//_, err = ringLWE.Encrypt(X.MulScalar(b), PK)
+	//assert.Error(t, err) // boundary violated
+	//cipher, err := ringLWE.Encrypt(X, PK)
+	//assert.NoError(t, err)
+	//
+	//xyDecrypted, err := ringLWE.Decrypt(cipher, skY, y)
+	//assert.NoError(t, err)
+	//assert.Equal(t, xy, xyDecrypted, "obtained incorrect inner product")
 }

--- a/innerprod/simple/ringlwe_test.go
+++ b/innerprod/simple/ringlwe_test.go
@@ -18,65 +18,80 @@ package simple_test
 
 import (
 	"fmt"
+	"github.com/fentec-project/gofe/data"
+	"github.com/fentec-project/gofe/sample"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/fentec-project/gofe/innerprod/simple"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSimple_RingLWE(t *testing.T) {
-	l := 64
-	n := 2048
+	l := 30
+	sec := 75
 	bx := big.NewInt(2)
 	by := big.NewInt(2)
-	//p, _ := new(big.Int).SetString("10000000000000000", 10)
-	//q, _ := new(big.Int).SetString("903468688179973616387830299599", 10)
 
-	//sigma := big.NewFloat(20)
-	//
-	//sampler := sample.NewUniformRange(new(big.Int).Neg(b), b)
-	//y, _ := data.NewRandomVector(l, sampler)
-	//X, _ := data.NewRandomMatrix(l, n, sampler)
-	//xy, _ := X.Transpose().MulVec(y)
-	//emptyVec := data.Vector{}
-	//emptyMat := data.Matrix{}
+	sampler := sample.NewUniformRange(new(big.Int).Neg(bx), bx)
+	y, _ := data.NewRandomVector(l, sampler)
 
-	//_, err := simple.NewRingLWE(l, 24, b, p, q, sigma)
-	//assert.Error(t, err) // n not a power of 2
-	//_, err = simple.NewRingLWE(l, n, b, big.NewInt(10), q, sigma)
-	//assert.Error(t, err) // precondition failed
-	ringLWE, err := simple.NewRingLWE(l, n, bx, by)
+	emptyVec := data.Vector{}
+	emptyMat := data.Matrix{}
+
+	ringLWE, err := simple.NewRingLWE(sec, l, bx, by)
+	X, _ := data.NewRandomMatrix(l, ringLWE.Params.N, sampler)
+	xy, _ := X.Transpose().MulVec(y)
+
 	assert.NoError(t, err)
 	fmt.Print(ringLWE)
-	//
-	//SK, err := ringLWE.GenerateSecretKey()
-	//assert.NoError(t, err)
-	//
-	//_, err = ringLWE.GeneratePublicKey(emptyMat)
-	//assert.Error(t, err)
-	//PK, err := ringLWE.GeneratePublicKey(SK)
-	//assert.NoError(t, err)
-	//
-	//_, err = ringLWE.DeriveKey(emptyVec, SK)
-	//assert.Error(t, err)
-	//_, err = ringLWE.DeriveKey(y, emptyMat)
-	//assert.Error(t, err)
-	//_, err = ringLWE.DeriveKey(y.MulScalar(b), SK)
-	//assert.Error(t, err) // boundary violated
-	//skY, err := ringLWE.DeriveKey(y, SK)
-	//assert.NoError(t, err)
-	//
-	//_, err = ringLWE.Encrypt(emptyMat, PK)
-	//assert.Error(t, err)
-	//_, err = ringLWE.Encrypt(X, emptyMat)
-	//assert.Error(t, err)
-	//_, err = ringLWE.Encrypt(X.MulScalar(b), PK)
-	//assert.Error(t, err) // boundary violated
-	//cipher, err := ringLWE.Encrypt(X, PK)
-	//assert.NoError(t, err)
-	//
-	//xyDecrypted, err := ringLWE.Decrypt(cipher, skY, y)
-	//assert.NoError(t, err)
-	//assert.Equal(t, xy, xyDecrypted, "obtained incorrect inner product")
+	start := time.Now()
+	SK, err := ringLWE.GenerateSecretKey()
+	assert.NoError(t, err)
+	elapsed := time.Since(start)
+	fmt.Println("sec key", elapsed.Seconds())
+
+	_, err = ringLWE.GeneratePublicKey(emptyMat)
+	assert.Error(t, err)
+	start = time.Now()
+
+	PK, err := ringLWE.GeneratePublicKey(SK)
+	assert.NoError(t, err)
+	elapsed = time.Since(start)
+	fmt.Println("pub key", elapsed.Seconds())
+
+	_, err = ringLWE.DeriveKey(emptyVec, SK)
+	assert.Error(t, err)
+	_, err = ringLWE.DeriveKey(y, emptyMat)
+	assert.Error(t, err)
+	start = time.Now()
+
+	skY, err := ringLWE.DeriveKey(y, SK)
+	assert.NoError(t, err)
+	elapsed = time.Since(start)
+	fmt.Println("der key", elapsed.Seconds())
+
+	_, err = ringLWE.Encrypt(emptyMat, PK)
+	assert.Error(t, err)
+	_, err = ringLWE.Encrypt(X, emptyMat)
+	assert.Error(t, err)
+
+	start = time.Now()
+
+	cipher, err := ringLWE.Encrypt(X, PK)
+	assert.NoError(t, err)
+	elapsed = time.Since(start)
+	fmt.Println("enc", elapsed.Seconds())
+
+	start = time.Now()
+
+	xyDecrypted, err := ringLWE.Decrypt(cipher, skY, y)
+	assert.NoError(t, err)
+	elapsed = time.Since(start)
+	fmt.Println("dec", elapsed.Seconds())
+	for i:=0; i < ringLWE.Params.N; i++ {
+		assert.Equal(t, xy[i].Cmp(xyDecrypted[i]), 0, "obtained incorrect inner product")
+
+	}
 }

--- a/innerprod/simple/ringlwe_test.go
+++ b/innerprod/simple/ringlwe_test.go
@@ -17,81 +17,70 @@
 package simple_test
 
 import (
-	"fmt"
 	"github.com/fentec-project/gofe/data"
 	"github.com/fentec-project/gofe/sample"
 	"math/big"
 	"testing"
-	"time"
 
 	"github.com/fentec-project/gofe/innerprod/simple"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSimple_RingLWE(t *testing.T) {
-	l := 30
-	sec := 75
-	bx := big.NewInt(2)
-	by := big.NewInt(2)
+	// choose meta-parameters
+	l := 30 // l-dimensional vectors
+	sec := 75 // min bits of security
+	bx := big.NewInt(2) // bound for the input coordinates
+	by := big.NewInt(2) // bound for the inner-product coordinates
 
+	// setup a ringLWE scheme
+	ringLWE, err := simple.NewRingLWE(sec, l, bx, by)
+	assert.NoError(t, err)
+
+	// sample an input and an inner-product vector
 	sampler := sample.NewUniformRange(new(big.Int).Neg(bx), bx)
 	y, _ := data.NewRandomVector(l, sampler)
-
-	emptyVec := data.Vector{}
-	emptyMat := data.Matrix{}
-
-	ringLWE, err := simple.NewRingLWE(sec, l, bx, by)
-	X, _ := data.NewRandomMatrix(l, ringLWE.Params.N, sampler)
+	dimX := ringLWE.Params.N / 2
+	X, _ := data.NewRandomMatrix(l, dimX, sampler)
 	xy, _ := X.Transpose().MulVec(y)
 
-	assert.NoError(t, err)
-	fmt.Print(ringLWE)
-	start := time.Now()
+	// generate a master secret key
 	SK, err := ringLWE.GenerateSecretKey()
 	assert.NoError(t, err)
-	elapsed := time.Since(start)
-	fmt.Println("sec key", elapsed.Seconds())
 
-	_, err = ringLWE.GeneratePublicKey(emptyMat)
-	assert.Error(t, err)
-	start = time.Now()
-
+    // generate a public key
 	PK, err := ringLWE.GeneratePublicKey(SK)
 	assert.NoError(t, err)
-	elapsed = time.Since(start)
-	fmt.Println("pub key", elapsed.Seconds())
 
+	// check if errors are raised if the input is of the wrong form
+	emptyVec := data.Vector{}
+	emptyMat := data.Matrix{}
+	_, err = ringLWE.GeneratePublicKey(emptyMat)
+	assert.Error(t, err)
 	_, err = ringLWE.DeriveKey(emptyVec, SK)
 	assert.Error(t, err)
 	_, err = ringLWE.DeriveKey(y, emptyMat)
 	assert.Error(t, err)
-	start = time.Now()
 
+	// derive FE key with respect to y
 	skY, err := ringLWE.DeriveKey(y, SK)
 	assert.NoError(t, err)
-	elapsed = time.Since(start)
-	fmt.Println("der key", elapsed.Seconds())
 
+	// encrypt a matrix X
+	cipher, err := ringLWE.Encrypt(X, PK)
+	assert.NoError(t, err)
+
+	// check if errors are raised if the input is of the wrong form
 	_, err = ringLWE.Encrypt(emptyMat, PK)
 	assert.Error(t, err)
 	_, err = ringLWE.Encrypt(X, emptyMat)
 	assert.Error(t, err)
 
-	start = time.Now()
-
-	cipher, err := ringLWE.Encrypt(X, PK)
-	assert.NoError(t, err)
-	elapsed = time.Since(start)
-	fmt.Println("enc", elapsed.Seconds())
-
-	start = time.Now()
-
+	// decrypt the product y^T * X using the derived key
 	xyDecrypted, err := ringLWE.Decrypt(cipher, skY, y)
 	assert.NoError(t, err)
-	elapsed = time.Since(start)
-	fmt.Println("dec", elapsed.Seconds())
-	for i:=0; i < ringLWE.Params.N; i++ {
+	// check the result
+	for i:=0; i < dimX; i++ {
 		assert.Equal(t, xy[i].Cmp(xyDecrypted[i]), 0, "obtained incorrect inner product")
-
 	}
 }


### PR DESCRIPTION
This PR implements ringLWE based inner-product FE scheme described in [paper](https://eprint.iacr.org/2021/046). To be more precise, the already implemented prototype is modified, so that the parameters of the scheme follow the requirements described in the paper and the additionally the security is determined based on so called primal attack on LWE problem.