### PR TITLE
Index out of range error

### DIFF
--- a/abe/ma-abe.go
+++ b/abe/ma-abe.go
@@ -369,7 +369,7 @@ func (a *MAABE) Encrypt(msg string, msp *MSP, pks []*MAABEPubKey) (*MAABECipher,
                 break
             }
         }
-        if foundPK == false {
+        if !foundPK {
             return nil, fmt.Errorf("attribute not found in any pubkey")
         }
     }

--- a/abe/ma-abe.go
+++ b/abe/ma-abe.go
@@ -471,6 +471,9 @@ func (a * MAABE) Decrypt(ct *MAABECipher, ks []*MAABEKey) (string, error) {
     //choose consts c_x, such that \sum c_x A_x = (1,0,...,0)
     // if they don't exist, keys are not ok
     goodCols := goodMat.Cols()
+    if goodCols == 0 {
+        return "", fmt.Errorf("no good matrix columns, most likely the keys contain no valid attribute")
+    }
     one := data.NewConstantVector(goodCols, big.NewInt(0))
     one[0] = big.NewInt(1)
     c, err := data.GaussianEliminationSolver(goodMat.Transpose(), one, a.P)

--- a/innerprod/simple/ringlwe.go
+++ b/innerprod/simple/ringlwe.go
@@ -120,7 +120,7 @@ func NewRingLWE(sec, l int, boundX, boundY *big.Int) (*RingLWE, error) {
 					break
 				}
 			}
-			if safe == false {
+			if !safe {
 				break
 			}
 		}


### PR DESCRIPTION
In ma-abe.go, if one tries to decrypt with a non-empty key set, none of which are contained in the decryption policy, this triggers an index out of bounds exception because of the hardcoded one[0] on line 478. This PR adds a check whether the goodCols variable is equal to 0, throwing an error if true. Also 2 minor stylistic fixes.